### PR TITLE
LNK-M-17 : 2차 qa 수정

### DIFF
--- a/app/(page)/_layout.tsx
+++ b/app/(page)/_layout.tsx
@@ -1,5 +1,5 @@
-import { Tabs } from 'expo-router';
-import React from 'react';
+import { Tabs, useFocusEffect, usePathname } from 'expo-router';
+import React, { useCallback } from 'react';
 import { useRouter } from 'expo-router';
 import styled from 'styled-components/native';
 import colors from '@/theme/color';
@@ -27,9 +27,20 @@ const TAB_CONFIG: readonly TabConfigItem[] = [
 
 export default function TabLayout() {
   const router = useRouter();
+  const pathname = usePathname();
   const openWriteMenu = useWriteMenuStore((s) => s.open);
   const isWriteMenuOpen = useWriteMenuStore((s) => s.isVisible);
   const closeWriteMenu = useWriteMenuStore((s) => s.close);
+
+  const isOnTabs = !pathname.startsWith('/(post)'); // (post) 스택일 땐 모달 숨기기
+
+  useFocusEffect(
+    useCallback(() => {
+      // 탭이 다시 보일 때, 혹시 열려 있으면 닫아버림
+      closeWriteMenu();
+      return () => closeWriteMenu(); // 탭에서 벗어날 때도 닫기
+    }, [closeWriteMenu]),
+  );
 
   return (
     <View style={{ flex: 1, backgroundColor: colors.bg[2] }}>
@@ -111,7 +122,7 @@ export default function TabLayout() {
             </StyledSafeArea>
 
             <MenuModal
-              visible={isWriteMenuOpen}
+              visible={isWriteMenuOpen && isOnTabs}
               onClose={closeWriteMenu}
               onPressFirst={() => {
                 closeWriteMenu();

--- a/app/(post)/feed.tsx
+++ b/app/(post)/feed.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import styled from 'styled-components/native';
 import { useRouter } from 'expo-router';
@@ -13,6 +13,7 @@ import { useFeedWriteStore } from '@/stores/feedWriteStore';
 import { getPresignedUrl, uploadImageToS3 } from '@/utils/s3Upload';
 import { Media } from '@/types/feed';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useModalStore } from '@/stores/modalStore';
 
 export default function PostFeedPage() {
   const insets = useSafeAreaInsets();
@@ -23,12 +24,13 @@ export default function PostFeedPage() {
   const resetSelectedImages = useFeedWriteStore.getState().reset;
 
   const setMediaUrls = useFeedWriteStore.getState().setMediaUrls;
-  const [isUploading, setIsUploading] = useState(false);
 
-  console.log('[🔁 selectedUrisLength]:', selectedUrisLength);
+  const closeModal = useModalStore((state) => state.closeModal);
 
-  const [isModalOpen, setIsModalOpen] = useState(false);
   const router = useRouter();
+
+  const [isUploading, setIsUploading] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const handleBackPress = () => {
     setIsModalOpen(true);

--- a/app/(post)/feed.tsx
+++ b/app/(post)/feed.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import styled from 'styled-components/native';
 import { useRouter } from 'expo-router';

--- a/app/(post)/feed.tsx
+++ b/app/(post)/feed.tsx
@@ -13,7 +13,6 @@ import { useFeedWriteStore } from '@/stores/feedWriteStore';
 import { getPresignedUrl, uploadImageToS3 } from '@/utils/s3Upload';
 import { Media } from '@/types/feed';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useModalStore } from '@/stores/modalStore';
 
 export default function PostFeedPage() {
   const insets = useSafeAreaInsets();
@@ -24,8 +23,6 @@ export default function PostFeedPage() {
   const resetSelectedImages = useFeedWriteStore.getState().reset;
 
   const setMediaUrls = useFeedWriteStore.getState().setMediaUrls;
-
-  const closeModal = useModalStore((state) => state.closeModal);
 
   const router = useRouter();
 
@@ -39,7 +36,7 @@ export default function PostFeedPage() {
   const handleConfirmExit = () => {
     setIsModalOpen(false);
     resetSelectedImages();
-    router.replace('/(page)/feed');
+    router.push('/(page)/feed');
   };
 
   const handleNext = async () => {

--- a/app/(post)/feed/[id]/index.tsx
+++ b/app/(post)/feed/[id]/index.tsx
@@ -19,13 +19,7 @@ import {
 import colors from '@/theme/color';
 import styled from 'styled-components/native';
 import { formatDate } from '@/utils/format-date';
-import {
-  Pressable,
-  Text,
-  TouchableOpacity,
-  TouchableWithoutFeedback,
-  View,
-} from 'react-native';
+import { Text, TouchableOpacity, View } from 'react-native';
 import { StyledText } from '@/app/(post)/feed/write';
 import { CONTAINER_PADDING } from '@/constants';
 import { useModalStore } from '@/stores/modalStore';
@@ -190,6 +184,7 @@ export default function FeedDetailPage() {
             totalReactionCount={feed.totalReactionCount}
             authorId={feed.author.userId}
             currentUserId={userInfo?.id}
+            flushOnExit
           />
         </RowWrapper>
 

--- a/app/(post)/feed/[id]/index.tsx
+++ b/app/(post)/feed/[id]/index.tsx
@@ -32,7 +32,6 @@ import { useUserStore } from '@/stores/userStore';
 import FeedReportModal from '@/components/Modal/FeedReportModal';
 import { useDetailFirstLaunch } from '@/hooks/useFirstLaunch';
 import OnBoardingModal from '@/components/Modal/OnBoardingModal';
-import GradientOverlay from '@/components/feed/GradientOverlay';
 
 export default function FeedDetailPage() {
   const { id } = useLocalSearchParams();
@@ -123,9 +122,11 @@ export default function FeedDetailPage() {
 
   return (
     <View style={{ flex: 1 }}>
-      <BackgroundImageSlider mediaUrls={feed.media} />
-      <GradientOverlay type="top" heightValue={120 * height} />
-      <GradientOverlay type="bottom" heightValue={520 * height} />
+      <BackgroundImageSlider
+        mediaUrls={feed.media}
+        gradient={{ top: 120 * height, bottom: 520 * height }}
+      />
+
       <Header
         isBackWhite
         RightSection="KEBAB"

--- a/app/(post)/feed/write.tsx
+++ b/app/(post)/feed/write.tsx
@@ -119,9 +119,11 @@ export default function FeedWritePage() {
         keyboardShouldPersistTaps="handled"
       >
         <View style={{ flex: 1 }}>
-          <BackgroundImageSlider mediaUrls={media} />
-          <GradientOverlay type="top" heightValue={120 * height} />
-          <GradientOverlay type="bottom" heightValue={520 * height} />
+          <BackgroundImageSlider
+            mediaUrls={media}
+            gradient={{ top: 120 * height, bottom: 420 * height }}
+          />
+
           <Header
             isBackWhite
             style={{

--- a/components/Modal/MenuModal.tsx
+++ b/components/Modal/MenuModal.tsx
@@ -111,8 +111,12 @@ const MenuItem = styled.View<{ pressed: boolean; $isWrite: boolean }>`
   flex-direction: row;
   align-items: center;
   justify-content: ${({ $isWrite }) => ($isWrite ? 'flex-start' : 'center')};
-  padding: ${4 * height}px ${4 * width}px;
-  border-radius: ${radius.md}px;
+  justify-content: center;
+  padding: ${({ pressed }) =>
+    pressed
+      ? `${4 * height}px ${12 * width}px`
+      : `${4 * height}px ${4 * width}px`};
+  border-radius: ${({ pressed }) => (pressed ? radius.sm : 0)}px;
   gap: ${({ $isWrite }) => ($isWrite ? 6 * width : 0)}px;
   background-color: ${({ pressed }) =>
     pressed ? colors.bg[3] : 'transparent'};

--- a/components/common/ImagePicker.tsx
+++ b/components/common/ImagePicker.tsx
@@ -72,6 +72,9 @@ export default function ImagePicker({
         onEndReached={() => {
           if (hasNextPage) fetchPhotos();
         }}
+        initialNumToRender={20}
+        windowSize={5}
+        removeClippedSubviews={true}
         renderItem={({ item }) => (
           <ThumbnailItem
             asset={item}

--- a/components/common/ImagePicker.tsx
+++ b/components/common/ImagePicker.tsx
@@ -72,7 +72,7 @@ export default function ImagePicker({
         onEndReached={() => {
           if (hasNextPage) fetchPhotos();
         }}
-        initialNumToRender={20}
+        initialNumToRender={12}
         windowSize={5}
         removeClippedSubviews={true}
         renderItem={({ item }) => (

--- a/components/feed/BackgroundImageSlider.tsx
+++ b/components/feed/BackgroundImageSlider.tsx
@@ -5,15 +5,31 @@ import styled from 'styled-components/native';
 import { radius, SCREEN_HEIGHT, SCREEN_WIDTH } from '@/theme/globalStyles';
 import { width as WIDTH, height as HEIGHT } from '@/theme/globalStyles';
 import { Media } from '@/types/feed';
+import GradientOverlay from '@/components/feed/GradientOverlay';
 
 interface BackgroundImageSliderProps {
   mediaUrls: Media[];
+  gradient?: {
+    top?: number; // px (예: 120 * HEIGHT)
+    bottom?: number; // px (예: 520 * HEIGHT)
+    showTop?: boolean; // 기본 true
+    showBottom?: boolean; // 기본 true
+  };
 }
+
+const DEFAULT_TOP = 120 * HEIGHT;
+const DEFAULT_BOTTOM = 520 * HEIGHT;
 
 export default function BackgroundImageSlider({
   mediaUrls,
+  gradient,
 }: BackgroundImageSliderProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
+
+  const topHeight = gradient?.top ?? DEFAULT_TOP;
+  const bottomHeight = gradient?.bottom ?? DEFAULT_BOTTOM;
+  const showTop = gradient?.showTop ?? true;
+  const showBottom = gradient?.showBottom ?? true;
 
   if (mediaUrls.length === 0) return null;
 
@@ -25,12 +41,27 @@ export default function BackgroundImageSlider({
           width={SCREEN_WIDTH}
           height={SCREEN_HEIGHT}
           data={mediaUrls}
-          onSnapToItem={(index) => setCurrentIndex(index)}
+          onSnapToItem={setCurrentIndex}
           renderItem={({ item }) => (
             <StyledBackground
               source={{ uri: item.mediaUrl }}
               resizeMode="cover"
-            />
+            >
+              {showTop && (
+                <GradientOverlay
+                  type="top"
+                  heightValue={topHeight}
+                  pointerEvents="none"
+                />
+              )}
+              {showBottom && (
+                <GradientOverlay
+                  type="bottom"
+                  heightValue={bottomHeight}
+                  pointerEvents="none"
+                />
+              )}
+            </StyledBackground>
           )}
           autoPlay={false}
           scrollAnimationDuration={500}
@@ -52,7 +83,6 @@ export default function BackgroundImageSlider({
 const Wrapper = styled.View`
   flex: 1;
   position: relative;
-  z-index: 9999;
 `;
 
 const CarouselWrapper = styled.View`
@@ -66,7 +96,6 @@ const CarouselWrapper = styled.View`
 const StyledBackground = styled(ImageBackground)`
   width: 100%;
   height: 100%;
-  z-index: 0;
 `;
 
 const IndicatorContainer = styled.View`

--- a/components/feed/GradientOverlay.tsx
+++ b/components/feed/GradientOverlay.tsx
@@ -6,11 +6,11 @@ import { height } from '@/theme/globalStyles';
 interface GradientOverlayProps {
   type: 'top' | 'bottom';
   style?: StyleProp<ViewStyle>;
-  colors?: [string, string] | string[];
+  colors?: [string, string];
   heightValue?: number;
   pointerEvents?: 'auto' | 'none' | 'box-none' | 'box-only';
   zIndex?: number;
-  locations?: number[];
+  locations?: [number, number];
 }
 
 const TOP_DEFAULT = ['rgba(0,0,0,0.55)', 'transparent'] as const;
@@ -35,7 +35,7 @@ export default function GradientOverlay({
       colors={gradientColors as [string, string]}
       start={{ x: 0.5, y: isTop ? 0 : 1 }}
       end={{ x: 0.5, y: isTop ? 1 : 0 }}
-      locations={locations as [number, number, ...number[]] | null | undefined}
+      locations={locations}
       style={[
         {
           position: 'absolute',

--- a/components/feed/GradientOverlay.tsx
+++ b/components/feed/GradientOverlay.tsx
@@ -6,35 +6,44 @@ import { height } from '@/theme/globalStyles';
 interface GradientOverlayProps {
   type: 'top' | 'bottom';
   style?: StyleProp<ViewStyle>;
-  colors?: string[];
+  colors?: [string, string] | string[];
   heightValue?: number;
+  pointerEvents?: 'auto' | 'none' | 'box-none' | 'box-only';
+  zIndex?: number;
+  locations?: number[];
 }
+
+const TOP_DEFAULT = ['rgba(0,0,0,0.55)', 'transparent'] as const;
+const BOTTOM_DEFAULT = ['rgba(0,0,0,0.6)', 'transparent'] as const;
 
 export default function GradientOverlay({
   type,
   style,
   colors,
   heightValue,
+  pointerEvents,
+  zIndex = 1,
+  locations,
 }: GradientOverlayProps) {
-  const defaultColors =
-    type === 'top'
-      ? ['rgba(0,0,0,0.55)', 'transparent']
-      : ['transparent', 'rgba(0,0,0,0.6)'];
+  const isTop = type === 'top';
+  const gradientColors = (colors ??
+    (isTop ? TOP_DEFAULT : BOTTOM_DEFAULT)) as string[];
 
   return (
     <LinearGradient
-      colors={
-        (colors as [string, string, ...string[]]) ||
-        (defaultColors as [string, string, ...string[]])
-      }
+      pointerEvents={pointerEvents ?? 'none'}
+      colors={gradientColors as [string, string]}
+      start={{ x: 0.5, y: isTop ? 0 : 1 }}
+      end={{ x: 0.5, y: isTop ? 1 : 0 }}
+      locations={locations as [number, number, ...number[]] | null | undefined}
       style={[
         {
           position: 'absolute',
           left: 0,
           right: 0,
-          height: heightValue || 160 * height,
-          zIndex: 10,
-          [type]: 0,
+          height: heightValue ?? 160 * height,
+          zIndex,
+          ...(isTop ? { top: 0 } : { bottom: 0 }),
         },
         style,
       ]}

--- a/components/feed/HeartButton.tsx
+++ b/components/feed/HeartButton.tsx
@@ -19,6 +19,7 @@ import { getFeedReactions } from '@/api/feed/feed.api';
 import useReactionDebounce from '@/hooks/useReactionDebounce';
 import { useToastStore } from '@/stores/toastStore';
 import { useModalStore } from '@/stores/modalStore';
+import useFlushOnExit from '@/hooks/useFlushonExit';
 
 type HeartData = {
   id: number;
@@ -30,6 +31,7 @@ interface HeartButtonProps {
   totalReactionCount: number;
   authorId: number;
   currentUserId: number | undefined;
+  flushOnExit?: boolean;
 }
 
 export default function HeartButton({
@@ -37,6 +39,7 @@ export default function HeartButton({
   totalReactionCount,
   authorId,
   currentUserId,
+  flushOnExit,
 }: HeartButtonProps) {
   const [hearts, setHearts] = useState<HeartData[]>([]);
   const [reactedUsers, setReactedUsers] = useState<FeedReactedUser[]>([]);
@@ -44,13 +47,15 @@ export default function HeartButton({
   const { modalType, openModal, closeModal } = useModalStore();
   const { showToast } = useToastStore();
 
-  const { count: localCount, increaseReaction } = useReactionDebounce(
-    feedId,
-    400,
-    (reactionCount) => {
-      setTotalReaction((prev) => prev + reactionCount);
-    },
-  );
+  const {
+    count: localCount,
+    increaseReaction,
+    flush,
+  } = useReactionDebounce(feedId, 500, (reactionCount) => {
+    setTotalReaction((prev) => prev + reactionCount);
+  });
+
+  useFlushOnExit(flushOnExit ?? false, flush, localCount);
 
   const heartScale = useSharedValue(1);
   const outlineScale = useSharedValue(0.8);

--- a/hooks/useFeedImagePicker.ts
+++ b/hooks/useFeedImagePicker.ts
@@ -38,7 +38,7 @@ export default function useFeedImagePicker({
 
     const { assets, endCursor, hasNextPage } =
       await MediaLibrary.getAssetsAsync({
-        first: 50,
+        first: 24,
         after: pageInfo?.endCursor ?? undefined,
         mediaType: MediaLibrary.MediaType.photo,
       });

--- a/hooks/useFlushonExit.ts
+++ b/hooks/useFlushonExit.ts
@@ -1,0 +1,36 @@
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import { useCallback } from 'react';
+
+/**
+ * 페이지를 벗어날 때 flush 함수를 호출하는 훅
+ * - 뒤로가기 버튼
+ * - iOS 스와이프 제스처
+ */
+export default function useFlushOnExit(
+  shouldFlush: boolean,
+  flushFn: () => void,
+  condition: number = 0, // 예: localCount
+) {
+  const navigation = useNavigation();
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!shouldFlush) return;
+
+      const onBeforeRemove = () => {
+        if (condition > 0) {
+          flushFn();
+        }
+      };
+
+      const unsubscribe = navigation.addListener(
+        'beforeRemove',
+        onBeforeRemove,
+      );
+
+      return () => {
+        unsubscribe();
+      };
+    }, [shouldFlush, flushFn, condition]),
+  );
+}

--- a/hooks/useReactionDebounce.ts
+++ b/hooks/useReactionDebounce.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import debounce from 'lodash.debounce';
 import { uploadFeedReactions } from '@/api/feed/feed.api';
 import { useToastStore } from '@/stores/toastStore';
@@ -12,67 +12,63 @@ export default function useReactionDebounce(
   const [count, setCount] = useState(0);
   const { showToast } = useToastStore();
 
-  const sendReactions = useCallback(
-    debounce(async (reactionCount: number) => {
-      if (reactionCount === 0) return;
+  // 1) 즉시 전송 함수 (공통 로직)
+  const performSend = useCallback(
+    async (reactionCount: number) => {
+      if (reactionCount <= 0) return;
 
       try {
-        console.log('Reaction Count 서버로 전송:', reactionCount);
+        // send
         await uploadFeedReactions(feedId, reactionCount);
-
         onSuccess?.(reactionCount);
-      } catch (error) {
-        const err = error as AxiosError;
-
-        console.error('❌ Reaction API Error:', err);
-
-        if (err.response) {
-          console.error('Response data:', err.response.data);
-          console.error('Response status:', err.response.status);
-        } else if (err.request) {
-          console.error('No response received. Request:', err.request);
-        } else {
-          console.error('Error setting up request:', err.message);
-        }
-
+      } catch (e) {
+        const err = e as AxiosError;
         if (err.response?.status === 403) {
           showToast('내 피드에는 공감할 수 없어!', 'error');
         } else {
           showToast('공감하기에 실패했어!', 'error');
         }
+        // 디버깅 로그는 필요 시 유지
+        console.error('[Reaction API Error]', err?.response ?? err);
       } finally {
+        // 전송이 실제로 끝난 뒤 카운트 리셋
         setCount(0);
       }
-    }, debounceTime),
-    [feedId, debounceTime, onSuccess],
+    },
+    [feedId, onSuccess, showToast],
   );
 
-  useEffect(() => {
-    if (count === 0) return;
-    sendReactions(count);
-  }, [count, sendReactions]);
+  // 2) 디바운스 래퍼 (performSend를 감쌈)
+  const debouncedSend = useMemo(
+    () =>
+      debounce((n: number) => {
+        void performSend(n);
+      }, debounceTime),
+    [performSend, debounceTime],
+  );
 
+  // count 변경 시 디바운스 호출
+  useEffect(() => {
+    if (count > 0) debouncedSend(count);
+  }, [count, debouncedSend]);
+
+  // 언마운트/의존성 변경 시 예약 취소
+  useEffect(() => {
+    return () => debouncedSend.cancel();
+  }, [debouncedSend]);
+
+  // +1
   const increaseReaction = useCallback(() => {
-    setCount((prev) => {
-      const newCount = prev + 1;
-      return newCount;
-    });
+    setCount((prev) => prev + 1);
   }, []);
 
-  useEffect(() => {
-    return () => {
-      sendReactions.cancel();
-    };
-  }, [sendReactions]);
+  // 3) flush: 예약 취소 후, 한 번만 즉시 전송
+  const flush = useCallback(() => {
+    debouncedSend.cancel();
+    if (count > 0) {
+      void performSend(count);
+    }
+  }, [debouncedSend, performSend, count]);
 
-  return {
-    count,
-    increaseReaction,
-    flush: () => {
-      sendReactions.flush();
-      if (count > 0) {
-        sendReactions(count);
-      }
-    },
-  };
+  return { count, increaseReaction, flush };
 }

--- a/hooks/useReactionDebounce.ts
+++ b/hooks/useReactionDebounce.ts
@@ -68,5 +68,11 @@ export default function useReactionDebounce(
   return {
     count,
     increaseReaction,
+    flush: () => {
+      sendReactions.flush();
+      if (count > 0) {
+        sendReactions(count);
+      }
+    },
   };
 }


### PR DESCRIPTION
- closed #34 

## 📝 Work Description

- 페이지나갈때 하트 누른거 잇는지없는지 체크해서 api요청 + 0.5초로 주기 줄이기
- 피드 작성하다가 뒤로갈 때 메뉴모달이 잠깐 깜빡하면서 열리는것.. 해결
- 게시물 삭제하기 버튼 pressed 영역 넓히기
- expo-media-library 로 갤러리 이미지 불러올 때 너무 느림 이슈,, 더 빠르게 불러올 수 있도록 수정
- 배경 그라데이션 리팩토링 

## 📸 Screenshot
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img width="300" src="이미지 주소" /> -->
### 배경그라데이션 적용 
<img width="564" height="1062" alt="image" src="https://github.com/user-attachments/assets/964f3241-4739-4f49-a5cf-e0b8d4212f31" />

### 메뉴모달 pressed 영역 넓힘 
<img width="625" height="619" alt="image" src="https://github.com/user-attachments/assets/909de678-a7c4-43fe-aa8f-100ca4f6a7dc" />


## 🚨Issue

## 📣 To Reviewers
다음 이슈에서는 input 클릭 시 버튼 위로올라오는 문제를 다시 해결해보겠습니다,,

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 배경 이미지 슬라이더에 상단/하단 그라데이션 오버레이 옵션 추가.
  * 좋아요(HeartButton) 컴포넌트에 화면 이탈 시 반영 플러시 기능 추가.
  * 화면 이탈 시 특정 작업을 수행하는 커스텀 훅 추가.

* **기능 개선**
  * 이미지 피커의 리스트 렌더링 및 메모리 최적화.
  * 피드 이미지 선택 시 한 번에 불러오는 사진 수 24장으로 감소.
  * 메뉴 모달이 탭 라우트에서만 표시되도록 조건 개선.
  * 피드 작성/상세 화면에서 그라데이션 적용 방식 통합 및 시각 효과 개선.
  * 좋아요 버튼의 디바운스(지연) 시간 500ms로 조정.
  * 메뉴 아이템 스타일이 눌림 상태에 따라 동적으로 변경되도록 개선.
  * 내비게이션 동작 방식 일부 개선(페이지 이동 방식 변경).

* **버그 수정 및 기타**
  * 불필요한 콘솔 로그 및 미사용 코드 제거.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->