### PR TITLE
LNK-M-20 2차 스프린트 내용 반영

### DIFF
--- a/api/feed/feed.api.ts
+++ b/api/feed/feed.api.ts
@@ -128,6 +128,14 @@ export const deleteFeed = async (feedId: number) => {
   return res.data.data;
 };
 
+// PATCH
+// 피드 수정
+export const patchFeed = async (feedId: number) => {
+  const res = await api.patch<ApiResponse<string>>(`/feeds/${feedId}`, {});
+  if (__DEV__) console.log('피드 수정 조회: ', res.data);
+  return res.data.data;
+};
+
 // ----------------------------------
 // 마이페이지
 // 내가 작성한 피드 목록 조회

--- a/app/(page)/feed.tsx
+++ b/app/(page)/feed.tsx
@@ -59,7 +59,6 @@ export default function FeedPage() {
       style={{
         flex: 1,
         backgroundColor: colors.bg[2],
-        // paddingHorizontal: 20 * width,
       }}
     >
       <Header

--- a/app/(page)/feed.tsx
+++ b/app/(page)/feed.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Header, FeedCard, CustomButton, Loading } from '@/components';
 import colors from '@/theme/color';
-import { View, FlatList } from 'react-native';
+import { View, FlatList, Platform } from 'react-native';
 import { width, height } from '@/theme/globalStyles';
 import BottomSheetModal from '@/components/Modal/BottomSheetModal';
 import { SubText, TitleText } from '@/components/OnBoarding';
@@ -11,6 +11,7 @@ import useFeedList from '@/hooks/useFeedList';
 import { useUserInfo } from '@/hooks/useUserInfo';
 import { useUserStore } from '@/stores/userStore';
 import { useBlockBackHandler } from '@/hooks/useBlockBackHandler';
+import { FEED_PADDING } from '@/constants';
 
 export default function FeedPage() {
   const firstLaunch = useFirstLaunch();
@@ -58,10 +59,14 @@ export default function FeedPage() {
       style={{
         flex: 1,
         backgroundColor: colors.bg[2],
-        paddingHorizontal: 20 * width,
+        // paddingHorizontal: 20 * width,
       }}
     >
-      <Header LeftSection="LOGO" RightSection="BELL" />
+      <Header
+        LeftSection="LOGO"
+        RightSection="BELL"
+        style={{ paddingHorizontal: FEED_PADDING * width }}
+      />
       <FlatList
         data={feeds}
         numColumns={2}
@@ -70,9 +75,10 @@ export default function FeedPage() {
         contentContainerStyle={{
           paddingBottom: 100 * height,
           paddingTop: 12 * height,
+          paddingHorizontal: FEED_PADDING * width,
         }}
         renderItem={({ item }) => <FeedCard item={item} />}
-        showsVerticalScrollIndicator={false}
+        showsVerticalScrollIndicator
         onEndReached={loadMore} // 스크롤 끝 도달 시 loadMore 실행
         onEndReachedThreshold={0.5} // 50% 스크롤 시점부터 호출
         refreshing={isRefreshing} // Pull to Refresh

--- a/app/(page)/leenk.tsx
+++ b/app/(page)/leenk.tsx
@@ -6,26 +6,31 @@ import { Header } from '@/components';
 import TabMenu from '@/components/common/TabMenu';
 import LeenkListItem from '@/components/leenk/LeenkListItem';
 import { mockLeenkData } from '@/constants/mockUserData';
+import { ContainerWithNoPadding } from '../account/my-feed';
+import { View } from 'react-native';
+import { FEED_PADDING } from '@/constants';
 
 export default function LeenkPage() {
   const [tab, setTab] = useState<'all' | 'recruiting' | 'completed'>('all');
 
   return (
-    <Container>
-      <Header LeftSection="LOGO" RightSection="BELL" />
-      <TabMenu
-        type="leenk"
-        activeTab={tab}
-        onTabChange={(newTab: string) => {
-          if (
-            newTab === 'all' ||
-            newTab === 'recruiting' ||
-            newTab === 'completed'
-          ) {
-            setTab(newTab);
-          }
-        }}
-      />
+    <ContainerWithNoPadding>
+      <View style={{ paddingHorizontal: FEED_PADDING * width }}>
+        <Header LeftSection="LOGO" RightSection="BELL" />
+        <TabMenu
+          type="leenk"
+          activeTab={tab}
+          onTabChange={(newTab: string) => {
+            if (
+              newTab === 'all' ||
+              newTab === 'recruiting' ||
+              newTab === 'completed'
+            ) {
+              setTab(newTab);
+            }
+          }}
+        />
+      </View>
       <List
         data={mockLeenkData}
         keyExtractor={(item) => item.id}
@@ -41,21 +46,16 @@ export default function LeenkPage() {
           />
         )}
         ItemSeparatorComponent={() => <Separator />}
-        showsVerticalScrollIndicator={false}
+        showsVerticalScrollIndicator
       />
-    </Container>
+    </ContainerWithNoPadding>
   );
 }
-
-const Container = styled.View`
-  flex: 1;
-  padding: 0 ${20 * width}px;
-  background-color: ${colors.bg[2]};
-`;
 
 const List = styled.FlatList.attrs({
   contentContainerStyle: {
     paddingBottom: height * 20,
+    paddingHorizontal: FEED_PADDING * width,
   },
 })``;
 

--- a/app/(post)/feed/[id]/index.tsx
+++ b/app/(post)/feed/[id]/index.tsx
@@ -29,7 +29,7 @@ import { deleteFeed, getFeedDetail } from '@/api/feed/feed.api';
 import { FeedDetail } from '@/types/feed';
 import { useEffect, useState } from 'react';
 import { useUserStore } from '@/stores/userStore';
-import FeedReportModal from '@/components/Modal/FeedReportModal';
+import FeedReportModal from '@/components/Modal/ReportModal';
 import { useDetailFirstLaunch } from '@/hooks/useFirstLaunch';
 import OnBoardingModal from '@/components/Modal/OnBoardingModal';
 import { useFeedWriteStore } from '@/stores/feedWriteStore';
@@ -267,7 +267,7 @@ export default function FeedDetailPage() {
         />
       )}
 
-      <FeedReportModal feedId={feed.feedId} />
+      <FeedReportModal type="feed" feedId={feed.feedId} />
 
       {/* 온보딩 */}
       {showOnBoarding && (

--- a/app/(post)/feed/[id]/index.tsx
+++ b/app/(post)/feed/[id]/index.tsx
@@ -32,6 +32,7 @@ import { useUserStore } from '@/stores/userStore';
 import FeedReportModal from '@/components/Modal/FeedReportModal';
 import { useDetailFirstLaunch } from '@/hooks/useFirstLaunch';
 import OnBoardingModal from '@/components/Modal/OnBoardingModal';
+import { useFeedWriteStore } from '@/stores/feedWriteStore';
 
 export default function FeedDetailPage() {
   const { id } = useLocalSearchParams();
@@ -47,6 +48,21 @@ export default function FeedDetailPage() {
   const [showOnBoarding, setShowOnBoarding] = useState(false);
 
   const isAuthor = feed?.author.userId === userInfo?.id;
+
+  const handleEdit = () => {
+    if (!feed) return;
+
+    closeModal();
+
+    const store = useFeedWriteStore.getState();
+    store.reset(); // 이전 편집 상태  초기화
+    store.startEditFromDetail(feed); // 현재 상세의 데이터를 프리필
+
+    router.push({
+      pathname: '/(post)/feed/write',
+      params: { mode: 'edit', feedId: String(feed?.feedId) },
+    });
+  };
 
   const handleDelete = () => {
     closeModal();
@@ -233,13 +249,7 @@ export default function FeedDetailPage() {
         isOneOption={!isAuthor}
         firstOptionText={isAuthor ? '수정하기' : '신고하기'}
         secondOptionText={isAuthor ? '삭제하기' : undefined}
-        onPressFirst={
-          isAuthor
-            ? () => {
-                /* TODO: 수정하기 */
-              }
-            : handleReport
-        }
+        onPressFirst={isAuthor ? handleEdit : handleReport}
         onPressSecond={isAuthor ? handleDelete : undefined}
       />
 

--- a/app/(post)/feed/[id]/index.tsx
+++ b/app/(post)/feed/[id]/index.tsx
@@ -21,7 +21,7 @@ import styled from 'styled-components/native';
 import { formatDate } from '@/utils/format-date';
 import { Text, TouchableOpacity, View } from 'react-native';
 import { StyledText } from '@/app/(post)/feed/write';
-import { CONTAINER_PADDING } from '@/constants';
+import { CONTAINER_PADDING, FEED_PADDING } from '@/constants';
 import { useModalStore } from '@/stores/modalStore';
 import { useToastStore } from '@/stores/toastStore';
 import { Link, router, useLocalSearchParams } from 'expo-router';
@@ -143,8 +143,7 @@ export default function FeedDetailPage() {
       {/* 본문 */}
       <View
         style={{
-          paddingHorizontal: CONTAINER_PADDING * width,
-          marginBottom: 24 * width,
+          paddingHorizontal: FEED_PADDING * width,
           minHeight: 220 * height,
           zIndex: 9999,
         }}
@@ -154,7 +153,6 @@ export default function FeedDetailPage() {
             style={{
               flexDirection: 'row',
               alignItems: 'center',
-              marginBottom: 16,
             }}
           >
             <Link href={`/users/${feed.author.userId}`} asChild>
@@ -191,8 +189,8 @@ export default function FeedDetailPage() {
 
         <View
           style={{
-            paddingHorizontal: 18 * width,
-            paddingBottom: 40 * height,
+            paddingHorizontal: 15 * width,
+            paddingBottom: 76 * height,
           }}
         >
           <Text
@@ -200,8 +198,8 @@ export default function FeedDetailPage() {
               color: colors.white,
               fontSize: fontSize.md,
               fontFamily: fonts.Bold,
-              marginBottom: 8,
-              minHeight: 126 * height,
+              paddingBottom: 8 * height,
+              minHeight: 90 * height,
               maxHeight: 126 * height,
             }}
           >
@@ -210,7 +208,7 @@ export default function FeedDetailPage() {
 
           <Text
             style={{
-              color: colors.text[4],
+              color: colors.white,
               fontSize: fontSize.md,
               fontFamily: fonts.Light,
               lineHeight: lineHeight.s,
@@ -232,9 +230,17 @@ export default function FeedDetailPage() {
         visible={modalType === 'menu'}
         isWrite={false}
         onClose={closeModal}
-        onPressFirst={() => {}}
-        secondOptionText={isAuthor ? '삭제하기' : '신고하기'}
-        onPressSecond={isAuthor ? handleDelete : handleReport}
+        isOneOption={!isAuthor}
+        firstOptionText={isAuthor ? '수정하기' : '신고하기'}
+        secondOptionText={isAuthor ? '삭제하기' : undefined}
+        onPressFirst={
+          isAuthor
+            ? () => {
+                /* TODO: 수정하기 */
+              }
+            : handleReport
+        }
+        onPressSecond={isAuthor ? handleDelete : undefined}
       />
 
       {modalType === 'deleteConfirm' && (

--- a/app/(post)/feed/link-members/index.tsx
+++ b/app/(post)/feed/link-members/index.tsx
@@ -15,7 +15,7 @@ import MemberBadgeList from '@/components/feed/MemberBadgeList';
 import { height, width } from '@/theme/globalStyles';
 import { useFeedWriteStore } from '@/stores/feedWriteStore';
 import { getAllUsers } from '@/api/feed/feed.api';
-import { CONTAINER_PADDING } from '@/constants';
+import { CONTAINER_PADDING, FEED_PADDING } from '@/constants';
 import colors from '@/theme/color';
 import styled from 'styled-components/native';
 import {
@@ -127,6 +127,6 @@ export default function LinkMembersPage() {
 
 const Container = styled(SafeAreaView)`
   flex: 1;
-  padding: 0 ${CONTAINER_PADDING * width}px;
+  padding: 0 ${FEED_PADDING * width}px;
   background-color: ${colors.gray[50]};
 `;

--- a/app/(post)/feed/write.tsx
+++ b/app/(post)/feed/write.tsx
@@ -8,7 +8,7 @@ import {
   Loading,
 } from '@/components';
 import colors from '@/theme/color';
-import { router } from 'expo-router';
+import { router, useLocalSearchParams } from 'expo-router';
 import {
   View,
   ScrollView,
@@ -18,12 +18,12 @@ import {
 } from 'react-native';
 import { Media } from '@/types/feed';
 import { fonts, fontSize, height, width } from '@/theme/globalStyles';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import PopupModal from '@/components/Modal/PopupModal';
 import styled from 'styled-components/native';
 import { useFeedWriteStore } from '@/stores/feedWriteStore';
 import FeedUploadModal from '@/components/Modal/FeedUploadingModal';
-import { uploadFeed } from '@/api/feed/feed.api';
+import { getFeedDetail, uploadFeed } from '@/api/feed/feed.api';
 import { useToastStore } from '@/stores/toastStore';
 import { useUserStore } from '@/stores/userStore';
 import useKeyboardAnimation from '@/hooks/useKeyboardAnimation';
@@ -31,18 +31,32 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { FEED_PADDING } from '@/constants';
 
 export default function FeedWritePage() {
-  const selectedImages = useFeedWriteStore((state) => state.selectedImages);
-  const connectedUsers = useFeedWriteStore((state) => state.users);
-  const description = useFeedWriteStore((state) => state.description);
-  const setDescription = useFeedWriteStore((state) => state.setDescription);
-  const mediaUrls = useFeedWriteStore((state) => state.mediaUrls);
+  const { mode, feedId } = useLocalSearchParams<{
+    mode?: 'edit' | 'create';
+    feedId?: string;
+  }>();
+  const isEditParam = mode === 'edit' && !!feedId;
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
-  const resetFeedWrite = useFeedWriteStore((state) => state.reset);
 
   const { showToast } = useToastStore();
   const { userInfo } = useUserStore();
+
+  const {
+    startCreate,
+    startEditFromDetail,
+    reset,
+    mediaUrls,
+    selectedImages,
+    users,
+    description,
+    setDescription,
+    reset: resetFeedWrite,
+    feedId: storeFeedId,
+  } = useFeedWriteStore();
+
+  const connectedUsers = users;
 
   const buttonTranslateY = useKeyboardAnimation(
     Platform.OS === 'ios' ? -390 * height : -85,
@@ -50,15 +64,23 @@ export default function FeedWritePage() {
 
   const insets = useSafeAreaInsets();
 
-  const media: Media[] = selectedImages.map((img, index) => ({
-    position: index + 1,
-    mediaUrl: img.uri,
-    mediaType: 'IMAGE' as const,
-  }));
+  // 기존 서버 이미지 + 로컬 새 이미지 합쳐서 슬라이더에 전달
+  const previewMedia: Media[] = [
+    ...mediaUrls.map((m) => ({
+      position: m.position,
+      mediaUrl: m.mediaUrl,
+      mediaType: m.mediaType,
+    })),
+    ...selectedImages.map((img, i) => ({
+      position: mediaUrls.length + i, // 뒤에 이어붙이기
+      mediaUrl: img.uri, // 로컬 uri
+      mediaType: 'IMAGE' as const,
+    })),
+  ];
 
   const requestBody = {
     description,
-    media: mediaUrls,
+    media: previewMedia,
     userId: connectedUsers.map((user) => user.userId),
   };
 
@@ -108,6 +130,56 @@ export default function FeedWritePage() {
     return <Loading />;
   }
 
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      if (!isEditParam) {
+        // create 모드
+        if (
+          mediaUrls.length > 0 ||
+          useFeedWriteStore.getState().isEdit ||
+          useFeedWriteStore.getState().feedId
+        ) {
+          useFeedWriteStore.setState({
+            isEdit: false,
+            feedId: undefined,
+            mediaUrls: [],
+          });
+        }
+        return;
+      }
+
+      if (
+        useFeedWriteStore.getState().feedId === Number(feedId) &&
+        mediaUrls.length > 0
+      )
+        return;
+
+      reset();
+      try {
+        const detail = await getFeedDetail(Number(feedId));
+        if (!cancelled) startEditFromDetail(detail);
+      } catch (e) {
+        if (!cancelled) {
+          showToast('피드 정보를 불러오지 못했어!', 'error');
+          router.back();
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    isEditParam,
+    feedId,
+    mediaUrls.length,
+    reset,
+    startEditFromDetail,
+    showToast,
+  ]);
+
   return (
     <KeyboardAvoidingView
       style={{ flex: 1 }}
@@ -120,7 +192,7 @@ export default function FeedWritePage() {
       >
         <View style={{ flex: 1 }}>
           <BackgroundImageSlider
-            mediaUrls={media}
+            mediaUrls={previewMedia}
             gradient={{ top: 120 * height, bottom: 420 * height }}
           />
 

--- a/app/(post)/feed/write.tsx
+++ b/app/(post)/feed/write.tsx
@@ -101,6 +101,11 @@ export default function FeedWritePage() {
 
   // 업로드 로직 분리
   const handleUploadFeed = async () => {
+    if (isEditParam) {
+      setIsModalOpen(true);
+      return;
+    }
+
     setIsUploading(true);
 
     try {
@@ -115,6 +120,14 @@ export default function FeedWritePage() {
     } finally {
       setIsUploading(false);
     }
+  };
+
+  const handleConfirmEdit = async () => {
+    setIsModalOpen(false);
+    // TODO: 수정 API 연결.
+
+    showToast('수정 완료!', 'success');
+    router.back();
   };
 
   const handleConfirmExit = () => {
@@ -135,32 +148,40 @@ export default function FeedWritePage() {
 
     (async () => {
       if (!isEditParam) {
-        // create 모드
-        if (
-          mediaUrls.length > 0 ||
-          useFeedWriteStore.getState().isEdit ||
-          useFeedWriteStore.getState().feedId
-        ) {
-          useFeedWriteStore.setState({
-            isEdit: false,
-            feedId: undefined,
-            mediaUrls: [],
-          });
+        // ------- 생성 모드 -------
+        const s = useFeedWriteStore.getState();
+
+        const hasDraft =
+          s.selectedImages.length > 0 ||
+          !!s.description?.trim() ||
+          s.users.length > 0;
+
+        const hasEditResidue = s.isEdit || !!s.feedId || s.mediaUrls.length > 0;
+
+        if (hasEditResidue) {
+          if (hasDraft) {
+            // 초안은 유지하고, 수정 전용 잔상만 제거
+            useFeedWriteStore.setState({
+              isEdit: false,
+              feedId: undefined,
+              mediaUrls: [],
+            });
+          } else {
+            // 초안이 없으면 완전 초기화
+            startCreate(); // selectedImages/users/description도 비움
+          }
         }
         return;
       }
 
-      if (
-        useFeedWriteStore.getState().feedId === Number(feedId) &&
-        mediaUrls.length > 0
-      )
-        return;
+      // ------- 수정 모드 보강 -------
+      if (storeFeedId === Number(feedId) && mediaUrls.length > 0) return;
 
       reset();
       try {
         const detail = await getFeedDetail(Number(feedId));
         if (!cancelled) startEditFromDetail(detail);
-      } catch (e) {
+      } catch {
         if (!cancelled) {
           showToast('피드 정보를 불러오지 못했어!', 'error');
           router.back();
@@ -175,8 +196,10 @@ export default function FeedWritePage() {
     isEditParam,
     feedId,
     mediaUrls.length,
-    reset,
+    storeFeedId,
+    startCreate,
     startEditFromDetail,
+    reset,
     showToast,
   ]);
 
@@ -260,20 +283,24 @@ export default function FeedWritePage() {
                 }}
                 disabled={description.trim().length === 0}
               >
-                업로드할래
+                {isEditParam ? '수정할래' : '업로드할래'}
               </CustomButton>
             </Animated.View>
           </View>
 
           <PopupModal
             isOpen={isModalOpen}
-            onRightBtn={handleConfirmUpload}
-            onLeftBtn={handleConfirmExit}
-            mainText="이 내용으로 피드에 업로드할까?"
-            subText="함께한 사람이 추가되지 않았어."
-            isCancel={true}
-            leftBtnText="추가할래"
-            rightBtnText="그냥 업로드할래"
+            onRightBtn={isEditParam ? handleConfirmEdit : handleConfirmUpload}
+            onLeftBtn={
+              isEditParam ? () => setIsModalOpen(false) : handleConfirmExit
+            }
+            mainText={
+              isEditParam ? '수정할까?' : '이 내용으로 피드에 업로드할까?'
+            }
+            subText={isEditParam ? undefined : '함께한 사람이 추가되지 않았어.'}
+            isCancel={!isEditParam}
+            leftBtnText={isEditParam ? '취소' : '추가할래'}
+            rightBtnText={isEditParam ? '수정할래' : '그냥 업로드할래'}
           />
         </View>
 

--- a/app/(post)/feed/write.tsx
+++ b/app/(post)/feed/write.tsx
@@ -295,7 +295,9 @@ export default function FeedWritePage() {
               isEditParam ? () => setIsModalOpen(false) : handleConfirmExit
             }
             mainText={
-              isEditParam ? '수정할까?' : '이 내용으로 피드에 업로드할까?'
+              isEditParam
+                ? '피드를 수정할까?'
+                : '이 내용으로 피드에 업로드할까?'
             }
             subText={isEditParam ? undefined : '함께한 사람이 추가되지 않았어.'}
             isCancel={!isEditParam}

--- a/app/(post)/feed/write.tsx
+++ b/app/(post)/feed/write.tsx
@@ -26,9 +26,9 @@ import FeedUploadModal from '@/components/Modal/FeedUploadingModal';
 import { uploadFeed } from '@/api/feed/feed.api';
 import { useToastStore } from '@/stores/toastStore';
 import { useUserStore } from '@/stores/userStore';
-import GradientOverlay from '@/components/feed/GradientOverlay';
 import useKeyboardAnimation from '@/hooks/useKeyboardAnimation';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { FEED_PADDING } from '@/constants';
 
 export default function FeedWritePage() {
   const selectedImages = useFeedWriteStore((state) => state.selectedImages);
@@ -135,7 +135,11 @@ export default function FeedWritePage() {
             }}
           />
           <View
-            style={{ paddingHorizontal: 16, marginBottom: 24, zIndex: 9999 }}
+            style={{
+              paddingHorizontal: FEED_PADDING * width,
+              marginBottom: 24,
+              zIndex: 9999,
+            }}
           >
             <Animated.View
               style={{
@@ -178,7 +182,7 @@ export default function FeedWritePage() {
                 size="lg"
                 onPress={handleUpload}
                 style={{
-                  marginTop: 16 * height,
+                  marginTop: 20 * height,
                   marginBottom:
                     Platform.OS === 'android' ? insets.bottom : 8 * height,
                 }}

--- a/app/(post)/feed/write.tsx
+++ b/app/(post)/feed/write.tsx
@@ -52,7 +52,6 @@ export default function FeedWritePage() {
     users,
     description,
     setDescription,
-    reset: resetFeedWrite,
     feedId: storeFeedId,
   } = useFeedWriteStore();
 
@@ -112,7 +111,7 @@ export default function FeedWritePage() {
       const res = await uploadFeed(requestBody);
       console.log('[피드 업로드 성공]:', res);
 
-      resetFeedWrite();
+      reset();
       router.push('/(page)/feed');
     } catch (error) {
       console.error('업로드 실패:', error);

--- a/app/(post)/leenk.tsx
+++ b/app/(post)/leenk.tsx
@@ -158,11 +158,13 @@ export default function PostLeenkPage() {
 
 const Row = styled.View`
   flex-direction: row;
+  margin-bottom: ${6 * height}px;
 `;
 
 const Margin = styled.View`
   height: ${height * 32}px;
 `;
+
 export const SubText = styled.Text`
   font-size: ${fontSize.sm}px;
   color: ${colors.primary};

--- a/app/(post)/leenk.tsx
+++ b/app/(post)/leenk.tsx
@@ -26,27 +26,37 @@ import { ScrollView } from 'react-native-gesture-handler';
 import styled from 'styled-components/native';
 
 export default function PostLeenkPage() {
+  const router = useRouter();
+
   const [isBackModalOpen, setIsBackModalOpen] = useState(false);
   const [completeModalOpen, setCompleteModalOpen] = useState(false);
   const [title, setTitle] = useState('');
   const [place, setPlace] = useState('');
-
+  const [date, setDate] = useState<Date | null>(null);
   const [content, setContent] = useState('');
-  const router = useRouter();
+
   const { resetLeenkImage } = useLeenkImageStore();
   const handleBackPress = () => setIsBackModalOpen(true);
+
   const handleConfirmExit = () => {
     setIsBackModalOpen(false);
-    router.replace('/(page)/leenk');
+    router.push('/(page)/leenk');
   };
+
   const handleComplete = () => {
     setCompleteModalOpen(false);
-    router.replace('/(page)/leenk');
+    router.push('/(page)/leenk');
   };
 
   useEffect(() => {
     resetLeenkImage();
   }, []);
+
+  const isFormValid =
+    title.trim().length > 0 &&
+    place.trim().length > 0 &&
+    content.trim().length > 0 &&
+    date !== null;
 
   return (
     <KeyboardAvoidingView
@@ -87,10 +97,10 @@ export default function PostLeenkPage() {
         />
         <Margin />
         <Title>
-          일시<Asterisk>*</Asterisk>
+          일시<Asterisk> *</Asterisk>
         </Title>
 
-        <CalendarButton />
+        <CalendarButton value={date} onChange={setDate} />
         <Margin />
         <Row>
           <Title>모임 인원</Title>
@@ -102,7 +112,11 @@ export default function PostLeenkPage() {
           title="내용"
           placeholder="자세한 내용을 입력해줘"
           maxLength={200}
+          minHeight={40}
+          maxHeight={50}
+          value={content}
           onChangeText={setContent}
+          fontSizeKey="lg"
           isRequired
         />
         <Margin />
@@ -113,7 +127,7 @@ export default function PostLeenkPage() {
           fullWidth
           rounded="md"
           size="lg"
-          disabled={place.trim() === '' || title.trim() === ''}
+          disabled={!isFormValid}
         >
           모집하자
         </CustomButton>
@@ -121,19 +135,20 @@ export default function PostLeenkPage() {
 
       <PopupModal
         isOpen={isBackModalOpen}
-        onRightBtn={() => setIsBackModalOpen(false)}
-        onLeftBtn={handleConfirmExit}
+        onRightBtn={handleConfirmExit}
+        onLeftBtn={() => setIsBackModalOpen(false)}
         mainText="글 작성을 그만둘래?"
         subText="작성하던 내용은 저장되지 않아."
         isCancel={true}
-        leftBtnText="확인"
-        rightBtnText="취소"
+        leftBtnText="취소"
+        rightBtnText="그만두기"
       />
       <PopupModal
         isOpen={completeModalOpen}
         onRightBtn={handleComplete}
         onLeftBtn={() => setCompleteModalOpen(false)}
         mainText="모집하러 가볼까?"
+        isCancel={false}
         leftBtnText="취소"
         rightBtnText="모집하기"
       />

--- a/app/(post)/leenk/[id]/index.tsx
+++ b/app/(post)/leenk/[id]/index.tsx
@@ -24,6 +24,7 @@ import { SubText, TitleText } from '@/components/OnBoarding';
 import { useState } from 'react';
 import LeenkContentSection from '@/components/leenk/LeenkDetailContent';
 import LeenkBottomButtonSection from '@/components/leenk/LeenkDetailBottomButton';
+import ReportModal from '@/components/Modal/ReportModal';
 
 export default function LeenkDetailPage() {
   const { id } = useLocalSearchParams<{ id: string | string[] }>();
@@ -164,22 +165,7 @@ export default function LeenkDetailPage() {
           />
         );
       case 'leenkReport':
-        return (
-          <PopupModal
-            isOpen
-            onRightBtn={() => {
-              closeModal();
-              showToast('신고가 접수됐어', 'success');
-            }}
-            onLeftBtn={closeModal}
-            isWarning
-            mainText="이 글을 신고할까?"
-            subText="허위 신고는 제재될 수 있어."
-            isCancel
-            leftBtnText="취소"
-            rightBtnText="신고할래"
-          />
-        );
+        return <ReportModal type="link" />; // TODO : 신고하기 api 연결 시 linkId 추가
       default:
         return null;
     }

--- a/app/(post)/leenk/[id]/index.tsx
+++ b/app/(post)/leenk/[id]/index.tsx
@@ -165,7 +165,7 @@ export default function LeenkDetailPage() {
           />
         );
       case 'leenkReport':
-        return <ReportModal type="link" />; // TODO : 신고하기 api 연결 시 linkId 추가
+        return <ReportModal type="leenk" />; // TODO : 신고하기 api 연결 시 linkId 추가
       default:
         return null;
     }

--- a/app/account/my-feed.tsx
+++ b/app/account/my-feed.tsx
@@ -1,33 +1,44 @@
-import { Container } from '@/app/(post)/feed';
 import { Header } from '@/components';
 import TabMenu from '@/components/common/TabMenu';
 import { useState } from 'react';
 import MyTotalReactionCount from '@/components/feed/MyTotalReactionCount';
 import ProfileFeedList from '@/components/feed/ProfileFeedList';
+import styled from 'styled-components/native';
+import colors from '@/theme/color';
+import { FEED_PADDING } from '@/constants';
+import { width } from '@/theme/globalStyles';
+import { View } from 'react-native';
 
 export default function MyFeedPage() {
   const [tab, setTab] = useState<'uploaded' | 'joined'>('uploaded');
   const [totalReactionCount, setTotalReactionCount] = useState(0);
 
   return (
-    <Container>
-      <Header RightSection="SETTING" />
-      <TabMenu
-        activeTab={tab}
-        onTabChange={(newTab: string) => {
-          if (newTab === 'uploaded' || newTab === 'joined') {
-            setTab(newTab);
-          }
-        }}
-      />
-      {tab === 'uploaded' && (
-        <MyTotalReactionCount totalReactionCount={totalReactionCount ?? 0} />
-      )}
+    <ContainerWithNoPadding>
+      <View style={{ paddingHorizontal: FEED_PADDING * width }}>
+        <Header RightSection="SETTING" />
+        <TabMenu
+          activeTab={tab}
+          onTabChange={(newTab: string) => {
+            if (newTab === 'uploaded' || newTab === 'joined') {
+              setTab(newTab);
+            }
+          }}
+        />
+        {tab === 'uploaded' && (
+          <MyTotalReactionCount totalReactionCount={totalReactionCount ?? 0} />
+        )}
+      </View>
       <ProfileFeedList
         key={tab}
         type={tab === 'uploaded' ? 'myFeed' : 'myJoined'}
         onTotalReactionCountChange={setTotalReactionCount}
       />
-    </Container>
+    </ContainerWithNoPadding>
   );
 }
+
+export const ContainerWithNoPadding = styled.View`
+  flex: 1;
+  background-color: ${colors.gray[50]};
+`;

--- a/app/account/notification-list.tsx
+++ b/app/account/notification-list.tsx
@@ -10,10 +10,11 @@ import {
 import { RefreshControl } from 'react-native-gesture-handler';
 import { ModalData, Notification } from '@/types/notification';
 import NotificationListItem from '@/components/NotificationListItem';
-import { width } from '@/theme/globalStyles';
+import { height, width } from '@/theme/globalStyles';
 import NotificationModal from '@/components/Modal/NotificationModal';
 import { useToastStore } from '@/stores/toastStore';
 import { useUserStore } from '@/stores/userStore';
+import { FEED_PADDING } from '@/constants';
 
 export default function NotificationListPage() {
   const [data, setData] = useState<Notification[]>([]);
@@ -69,11 +70,15 @@ export default function NotificationListPage() {
 
   return (
     <Container>
-      <Header />
+      <Header style={{ paddingHorizontal: FEED_PADDING * width }} />
       <FlatList
         data={data}
         keyExtractor={(item) => item.id}
-        showsVerticalScrollIndicator={false}
+        showsVerticalScrollIndicator
+        contentContainerStyle={{
+          paddingHorizontal: FEED_PADDING * width,
+          marginTop: 8 * height,
+        }}
         renderItem={({ item }) => (
           <NotificationListItem
             item={item}
@@ -109,5 +114,5 @@ export default function NotificationListPage() {
 const Container = styled.View`
   flex: 1;
   background-color: ${colors.bg[1]};
-  padding-horizontal: ${20 * width}px;
+  /* padding-horizontal: ${20 * width}px; */
 `;

--- a/app/users/[id]/index.tsx
+++ b/app/users/[id]/index.tsx
@@ -86,18 +86,16 @@ export default function MyPage() {
           });
         }}
       />
-      {/* <MyPageButton
+      <MyPageButton
         text="참여한 모임"
         onPress={() => router.push('/account/my-leenk')}
-      /> */}
+      />
       <MenuModal
         visible={modalType === 'menu'}
         isWrite={false}
         onClose={closeModal}
-        onPressFirst={() => {}} // 추후 수정하기 옵션 추가 시 사용
-        onPressSecond={handleBlock}
-        secondOptionText="차단하기"
-        isDanger
+        onPressFirst={handleBlock}
+        firstOptionText="차단하기"
       />
       {modalType === 'deleteConfirm' && (
         <PopupModal

--- a/app/users/feed/index.tsx
+++ b/app/users/feed/index.tsx
@@ -4,9 +4,12 @@ import TabMenu from '@/components/common/TabMenu';
 import { FlatList } from 'react-native';
 import { useEffect, useState } from 'react';
 import styled from 'styled-components/native';
-import { height } from '@/theme/globalStyles';
+import { height, width } from '@/theme/globalStyles';
 import useFeedList from '@/hooks/useFeedList';
 import { useLocalSearchParams } from 'expo-router';
+import { ContainerWithNoPadding } from '@/app/account/my-feed';
+import { FEED_PADDING } from '@/constants';
+import { View } from 'react-native';
 
 export default function OtherUserProfilePage() {
   const { userId } = useLocalSearchParams<{ userId: string }>();
@@ -32,16 +35,18 @@ export default function OtherUserProfilePage() {
   if (!feeds) return null;
 
   return (
-    <Container>
-      <Header />
-      <TabMenu
-        activeTab={tab}
-        onTabChange={(newTab: string) => {
-          if (newTab === 'uploaded' || newTab === 'joined') {
-            setTab(newTab);
-          }
-        }}
-      />
+    <ContainerWithNoPadding>
+      <View style={{ paddingHorizontal: FEED_PADDING * width }}>
+        <Header />
+        <TabMenu
+          activeTab={tab}
+          onTabChange={(newTab: string) => {
+            if (newTab === 'uploaded' || newTab === 'joined') {
+              setTab(newTab);
+            }
+          }}
+        />
+      </View>
       <Content>
         <FlatList
           data={feeds}
@@ -50,9 +55,10 @@ export default function OtherUserProfilePage() {
           columnWrapperStyle={{ justifyContent: 'space-between' }}
           contentContainerStyle={{
             paddingBottom: 100 * height,
+            paddingHorizontal: FEED_PADDING * width,
           }}
           renderItem={({ item }) => <FeedCard item={item} />}
-          showsVerticalScrollIndicator={false}
+          showsVerticalScrollIndicator
           onEndReached={loadMore}
           onEndReachedThreshold={0.5}
           refreshing={isRefreshing}
@@ -62,7 +68,7 @@ export default function OtherUserProfilePage() {
           }
         />
       </Content>
-    </Container>
+    </ContainerWithNoPadding>
   );
 }
 

--- a/components/Modal/FeedReportModal.tsx
+++ b/components/Modal/FeedReportModal.tsx
@@ -30,7 +30,7 @@ export default function FeedReportModal({ feedId }: FeedReportModalProps) {
   const handleSubmit = async () => {
     try {
       await reportFeed(feedId, report);
-      showToast('해당 피드를 신고했어!', 'success');
+      showToast('해당 피드를 신고했어', 'success');
     } catch (error) {
       console.error('피드 신고 실패:', error);
       showToast('신고 실패!', 'error');

--- a/components/Modal/MenuModal.tsx
+++ b/components/Modal/MenuModal.tsx
@@ -37,7 +37,7 @@ export default function MenuModal({
 }: MenuModalProps) {
   const topPosition = Platform.OS === 'ios' ? 95 * height : 50 * height;
 
-  const DANGER_LABELS = ['신고하기', '삭제하기'] as const;
+  const DANGER_LABELS = ['신고하기', '삭제하기', '차단하기'] as const;
 
   return (
     <Modal
@@ -84,7 +84,7 @@ export default function MenuModal({
                     <MenuText
                       $isWrite={isWrite}
                       $isDanger={DANGER_LABELS.includes(
-                        firstOptionText as '신고하기' | '삭제하기',
+                        firstOptionText as '신고하기' | '삭제하기' | '차단하기',
                       )}
                     >
                       {firstOptionText}
@@ -100,7 +100,10 @@ export default function MenuModal({
                       <MenuText
                         $isWrite={isWrite}
                         $isDanger={DANGER_LABELS.includes(
-                          secondOptionText as '신고하기' | '삭제하기',
+                          secondOptionText as
+                            | '신고하기'
+                            | '삭제하기'
+                            | '차단하기',
                         )}
                       >
                         {secondOptionText}

--- a/components/Modal/MenuModal.tsx
+++ b/components/Modal/MenuModal.tsx
@@ -36,6 +36,9 @@ export default function MenuModal({
   isOneOption = true,
 }: MenuModalProps) {
   const topPosition = Platform.OS === 'ios' ? 95 * height : 50 * height;
+
+  const DANGER_LABELS = ['신고하기', '삭제하기'] as const;
+
   return (
     <Modal
       transparent
@@ -78,18 +81,28 @@ export default function MenuModal({
               <MenuItemWrapper onPress={onPressFirst}>
                 {({ pressed }) => (
                   <MenuItem pressed={pressed} $isWrite={isWrite}>
-                    <MenuText $isWrite={isWrite} $isDanger={isDanger}>
+                    <MenuText
+                      $isWrite={isWrite}
+                      $isDanger={DANGER_LABELS.includes(
+                        firstOptionText as '신고하기' | '삭제하기',
+                      )}
+                    >
                       {firstOptionText}
                     </MenuText>
                   </MenuItem>
                 )}
               </MenuItemWrapper>
 
-              {!isOneOption && (
+              {secondOptionText && !isOneOption && (
                 <MenuItemWrapper onPress={onPressSecond}>
                   {({ pressed }) => (
                     <MenuItem pressed={pressed} $isWrite={isWrite}>
-                      <MenuText $isWrite={isWrite} $isDanger={isDanger}>
+                      <MenuText
+                        $isWrite={isWrite}
+                        $isDanger={DANGER_LABELS.includes(
+                          secondOptionText as '신고하기' | '삭제하기',
+                        )}
+                      >
                         {secondOptionText}
                       </MenuText>
                     </MenuItem>

--- a/components/Modal/MenuModal.tsx
+++ b/components/Modal/MenuModal.tsx
@@ -83,9 +83,15 @@ export default function MenuModal({
                   <MenuItem pressed={pressed} $isWrite={isWrite}>
                     <MenuText
                       $isWrite={isWrite}
-                      $isDanger={DANGER_LABELS.includes(
-                        firstOptionText as '신고하기' | '삭제하기' | '차단하기',
-                      )}
+                      $isDanger={
+                        isDanger ||
+                        DANGER_LABELS.includes(
+                          firstOptionText as
+                            | '신고하기'
+                            | '삭제하기'
+                            | '차단하기',
+                        )
+                      }
                     >
                       {firstOptionText}
                     </MenuText>

--- a/components/Modal/ReportModal.tsx
+++ b/components/Modal/ReportModal.tsx
@@ -17,22 +17,22 @@ import { useToastStore } from '@/stores/toastStore';
 import { reportFeed } from '@/api/feed/feed.api';
 
 interface ReportModalProps {
-  type: 'feed' | 'link';
+  type: 'feed' | 'leenk';
   feedId?: number;
-  linkId?: number;
+  leenkId?: number;
 }
 
 export default function ReportModal({
   type = 'feed',
   feedId,
-  linkId,
+  leenkId,
 }: ReportModalProps) {
   const [report, setReport] = useState('');
   const { modalType, closeModal } = useModalStore();
   const { showToast } = useToastStore();
 
   const isOpen = modalType === `${type}Report`;
-  const targetId = type === 'feed' ? feedId : linkId;
+  const targetId = type === 'feed' ? feedId : leenkId;
 
   const handleSubmit = async () => {
     if (!targetId) {

--- a/components/Modal/ReportModal.tsx
+++ b/components/Modal/ReportModal.tsx
@@ -16,27 +16,46 @@ import { useModalStore } from '@/stores/modalStore';
 import { useToastStore } from '@/stores/toastStore';
 import { reportFeed } from '@/api/feed/feed.api';
 
-interface FeedReportModalProps {
-  feedId: number;
+interface ReportModalProps {
+  type: 'feed' | 'link';
+  feedId?: number;
+  linkId?: number;
 }
 
-export default function FeedReportModal({ feedId }: FeedReportModalProps) {
-  const [report, setreport] = useState('');
+export default function ReportModal({
+  type = 'feed',
+  feedId,
+  linkId,
+}: ReportModalProps) {
+  const [report, setReport] = useState('');
   const { modalType, closeModal } = useModalStore();
   const { showToast } = useToastStore();
 
-  const isOpen = modalType === 'feedReport';
+  const isOpen = modalType === `${type}Report`;
+  const targetId = type === 'feed' ? feedId : linkId;
 
   const handleSubmit = async () => {
+    if (!targetId) {
+      console.error('신고할 ID가 없습니다.');
+      return;
+    }
+
     try {
-      await reportFeed(feedId, report);
-      showToast('해당 피드를 신고했어', 'success');
+      if (type === 'feed') {
+        await reportFeed(targetId, report);
+      } else {
+        // TODO: 링크 신고 API
+      }
+      showToast(
+        `해당 ${type === 'feed' ? '피드' : '링크'}를 신고했어`,
+        'success',
+      );
     } catch (error) {
-      console.error('피드 신고 실패:', error);
+      console.error(`${type} 신고 실패:`, error);
       showToast('신고 실패!', 'error');
     } finally {
       closeModal();
-      setreport('');
+      setReport('');
     }
   };
 
@@ -58,13 +77,16 @@ export default function FeedReportModal({ feedId }: FeedReportModalProps) {
           >
             <SheetContainer>
               <SheetBox>
-                <Title>해당 피드를 신고하는 이유를 알려줘</Title>
+                <Title>
+                  해당 {type === 'feed' ? '피드' : '링크'}를 신고하는 이유를
+                  알려줘
+                </Title>
                 <SubText>빠르게 확인하고 조치를 취해줄게!</SubText>
 
                 <Textarea
                   placeholder="텍스트를 입력해 주세요"
                   value={report}
-                  onChangeText={setreport}
+                  onChangeText={setReport}
                   maxLength={100}
                   minHeight={30}
                   maxHeight={40}

--- a/components/common/Badge.tsx
+++ b/components/common/Badge.tsx
@@ -40,7 +40,7 @@ export default function Badge({
       {/* 왼쪽 아이콘: plus */}
       {iconType === 'plus' && (
         <IconWrapper style={{ marginRight: 4 }}>
-          <PlusIcon width={18} height={18} />
+          <PlusIcon width={18} height={18} color={colors.white} />
         </IconWrapper>
       )}
 

--- a/components/common/CheckBox.tsx
+++ b/components/common/CheckBox.tsx
@@ -1,9 +1,9 @@
 import { CheckBoxIcon, ToastCheckIcon, CheckIcon, NoCheckIcon } from '@/assets';
-import { Pressable } from 'react-native';
+import { GestureResponderEvent, Pressable } from 'react-native';
 
 interface CheckBoxProps {
   checked: boolean;
-  onPress?: () => void;
+  onPress?: (e: GestureResponderEvent) => void;
   noBox?: boolean; // 박스 없는 체크 표시 여부
 }
 
@@ -13,7 +13,13 @@ export default function CheckBox({
   noBox = false,
 }: CheckBoxProps) {
   return (
-    <Pressable onPress={onPress} hitSlop={10}>
+    <Pressable
+      hitSlop={10}
+      onPress={(e) => {
+        e.stopPropagation(); // 부모 Wrapper onPress로 전파 방지
+        onPress?.(e);
+      }}
+    >
       {noBox ? (
         checked ? (
           <CheckIcon />

--- a/components/common/CheckBox.tsx
+++ b/components/common/CheckBox.tsx
@@ -3,7 +3,7 @@ import { GestureResponderEvent, Pressable } from 'react-native';
 
 interface CheckBoxProps {
   checked: boolean;
-  onPress?: (e: GestureResponderEvent) => void;
+  onPress?: (e?: GestureResponderEvent) => void;
   noBox?: boolean; // 박스 없는 체크 표시 여부
 }
 

--- a/components/common/Input.tsx
+++ b/components/common/Input.tsx
@@ -1,7 +1,14 @@
 import React, { useState } from 'react';
 import { TextInputProps } from 'react-native';
 import styled from 'styled-components/native';
-import { fontSize, radius, height, width, fonts } from '@/theme/globalStyles';
+import {
+  fontSize,
+  radius,
+  height,
+  width,
+  fonts,
+  lineHeight,
+} from '@/theme/globalStyles';
 import colors from '@/theme/color';
 import { Asterisk } from './Textarea';
 
@@ -25,7 +32,7 @@ export default function Input({
       {title && (
         <Title>
           {title}
-          {isRequired && <Asterisk>*</Asterisk>}
+          {isRequired && <Asterisk> *</Asterisk>}
         </Title>
       )}
 
@@ -65,9 +72,12 @@ export const Title = styled.Text`
 export const InputBox = styled.View<{ focused: boolean }>`
   width: 100%;
   border-radius: ${radius.sm}px;
+  justify-content: center;
   padding-vertical: ${12 * height}px;
+  height: ${48 * height}px;
   padding-horizontal: ${12 * width}px;
-  border-width: 2px;
+  border-width: ${({ focused }) => (focused ? 2 : 1)}px;
+
   border-color: ${({ focused }) =>
     focused ? colors.primaryLight : colors.gray[300]};
   border-style: solid;
@@ -80,8 +90,13 @@ export const InputBox = styled.View<{ focused: boolean }>`
 
 export const StyledTextInput = styled.TextInput`
   width: 100%;
+  height: ${24 * height}px;
   font-size: ${fontSize.lg}px;
+  font-family: ${fonts.Regular};
   color: ${colors.black};
+  display: flex;
+  justify-content: center;
+  align-items: center;
   padding: 0;
 `;
 

--- a/components/common/Input.tsx
+++ b/components/common/Input.tsx
@@ -59,7 +59,7 @@ export default function Input({
 
 export const Wrapper = styled.View`
   width: 100%;
-  gap: 8px;
+  gap: ${12 * height}px;
   font-family: ${fonts.Regular};
 `;
 

--- a/components/common/Textarea.tsx
+++ b/components/common/Textarea.tsx
@@ -32,7 +32,6 @@ export default function Textarea({
 }: TextareaProps) {
   const [focused, setFocused] = useState(false);
   const isDark = variant === 'dark';
-  const isActive = !!value && value.length > 0;
 
   return (
     <Wrapper>
@@ -76,7 +75,6 @@ export default function Textarea({
 
 const InputBox = styled.View<{
   focused: boolean;
-  active: boolean;
   isDark: boolean;
 }>`
   width: 100%;

--- a/components/common/Textarea.tsx
+++ b/components/common/Textarea.tsx
@@ -42,7 +42,7 @@ export default function Textarea({
           {isRequired && <Asterisk> *</Asterisk>}
         </Title>
       )}
-      <InputBox focused={focused} active={isActive} isDark={isDark}>
+      <InputBox focused={focused} isDark={isDark}>
         <StyledTextarea
           {...props}
           placeholder={placeholder}
@@ -83,14 +83,9 @@ const InputBox = styled.View<{
   border-radius: ${radius.sm}px;
   padding-vertical: ${12 * height}px;
   padding-horizontal: ${12 * width}px;
-  border-width: ${({ focused, active, isDark }) => {
-    if (focused) return 2;
-    return isDark ? (active ? 1 : 0) : 1;
-  }}px;
-  border-color: ${({ focused, active, isDark }) => {
-    if (focused || active) return colors.primaryLight;
-    return isDark ? 'transparent' : colors.gray[300];
-  }};
+  border-width: ${({ focused, isDark }) => (focused ? 2 : isDark ? 0 : 1)}px;
+  border-color: ${({ focused, isDark }) =>
+    focused ? colors.primaryLight : isDark ? 'transparent' : colors.gray[300]};
   border-style: solid;
   background-color: ${({ isDark }) =>
     isDark ? 'rgba(255, 255, 255, 0.2)' : 'transparent'};

--- a/components/common/Textarea.tsx
+++ b/components/common/Textarea.tsx
@@ -13,6 +13,7 @@ interface TextareaProps extends TextInputProps {
   minHeight?: number;
   maxHeight?: number;
   isRequired?: boolean;
+  fontSizeKey?: keyof typeof fontSize;
 }
 
 export default function Textarea({
@@ -26,6 +27,7 @@ export default function Textarea({
   value,
   isRequired = false,
   onChangeText,
+  fontSizeKey = 'md',
   ...props
 }: TextareaProps) {
   const [focused, setFocused] = useState(false);
@@ -37,7 +39,7 @@ export default function Textarea({
       {title && (
         <Title>
           {title}
-          {isRequired && <Asterisk>*</Asterisk>}
+          {isRequired && <Asterisk> *</Asterisk>}
         </Title>
       )}
       <InputBox focused={focused} active={isActive} isDark={isDark}>
@@ -52,6 +54,7 @@ export default function Textarea({
           minHeight={minHeight}
           maxHeight={maxHeight}
           onChangeText={onChangeText}
+          fontSizeKey={fontSizeKey}
           onFocus={(e) => {
             setFocused(true);
             props.onFocus?.(e);
@@ -80,10 +83,12 @@ const InputBox = styled.View<{
   border-radius: ${radius.sm}px;
   padding-vertical: ${12 * height}px;
   padding-horizontal: ${12 * width}px;
-  border-width: ${({ focused, active, isDark }) =>
-    isDark ? (focused || active ? '1px' : '0px') : '1px'};
+  border-width: ${({ focused, active, isDark }) => {
+    if (focused) return 2;
+    return isDark ? (active ? 1 : 0) : 1;
+  }}px;
   border-color: ${({ focused, active, isDark }) => {
-    if (focused || active) return colors.violet[400];
+    if (focused || active) return colors.primaryLight;
     return isDark ? 'transparent' : colors.gray[300];
   }};
   border-style: solid;
@@ -95,13 +100,14 @@ const StyledTextarea = styled.TextInput<{
   isDark: boolean;
   minHeight?: number;
   maxHeight?: number;
+  fontSizeKey: keyof typeof fontSize;
 }>`
   width: 100%;
   min-height: ${({ minHeight }) =>
     minHeight ? `${minHeight * height}px` : `${74 * height}px`};
   max-height: ${({ maxHeight }) =>
     maxHeight ? `${maxHeight * height}px` : `${85 * height}px`};
-  font-size: ${fontSize.md}px;
+  font-size: ${({ fontSizeKey }) => fontSize[fontSizeKey]}px;
   font-family: ${fonts.Bold};
   color: ${({ isDark }) => (isDark ? colors.white : colors.black)};
   text-align-vertical: top;

--- a/components/feed/FeedDetailItem.tsx
+++ b/components/feed/FeedDetailItem.tsx
@@ -174,6 +174,7 @@ export default function FeedDetailItem({ feed }: Props) {
         isWrite={false}
         onClose={closeModal}
         onPressFirst={() => {}} // 추후 수정하기 옵션 추가 시 사용
+        firstOptionText={isAuthor ? '수정하기' : ''}
         secondOptionText={isAuthor ? '삭제하기' : '신고하기'}
         onPressSecond={isAuthor ? handleDelete : handleReport}
       />

--- a/components/feed/FeedDetailItem.tsx
+++ b/components/feed/FeedDetailItem.tsx
@@ -1,13 +1,7 @@
-// 상세 피드에서 수직 스크롤을 위해 분리한 컴포넌트
-// TODO: 상세 피드에서 위아래 스크롤 시 이전/다음 피드로 넘어가도록 해야함
-
-import {
-  fonts,
-  fontSize,
-  height,
-  lineHeight,
-  width,
-} from '@/theme/globalStyles';
+import React, { useCallback, useMemo } from 'react';
+import styled from 'styled-components/native';
+import { View, Text, TouchableOpacity } from 'react-native';
+import { Link, router } from 'expo-router';
 import {
   Header,
   BackgroundImageSlider,
@@ -18,20 +12,25 @@ import {
   MenuModal,
   PopupModal,
 } from '@/components';
-import colors from '@/theme/color';
-import { formatDate } from '@/utils/format-date';
-import { Text, View } from 'react-native';
-import { StyledText } from '@/app/(post)/feed/write';
-import { CONTAINER_PADDING } from '@/constants';
-import { useModalStore } from '@/stores/modalStore';
-import { useToastStore } from '@/stores/toastStore';
-import { router } from 'expo-router';
+
 import { deleteFeed } from '@/api/feed/feed.api';
 import { FeedDetail } from '@/types/feed';
+import { formatDate } from '@/utils/format-date';
+import colors from '@/theme/color';
+import { useModalStore } from '@/stores/modalStore';
+import { useToastStore } from '@/stores/toastStore';
 import { useUserStore } from '@/stores/userStore';
-import styled from 'styled-components/native';
-import { useCallback } from 'react';
-import FeedReportModal from '../Modal/FeedReportModal';
+import FeedReportModal from '@/components/Modal/FeedReportModal';
+import {
+  fonts,
+  fontSize,
+  height,
+  lineHeight,
+  width,
+} from '@/theme/globalStyles';
+import { CONTAINER_PADDING, FEED_PADDING } from '@/constants';
+import { StyledText } from '@/app/(post)/feed/write';
+import { Media } from '@/types/feed';
 
 interface Props {
   feed: FeedDetail;
@@ -42,8 +41,77 @@ export default function FeedDetailItem({ feed }: Props) {
   const { showToast } = useToastStore();
   const { userInfo } = useUserStore();
 
-  const isAuthor = feed.author.userId === userInfo?.id;
+  // ─────────────────────────────────────────────
+  // 1) media 안전 폴백 + BackgroundImageSlider 타입 맞추기
+  //    - 컴포넌트가 Media[] (ex: {url, type}) 를 기대하는 경우를 맞춰줌
+  // ─────────────────────────────────────────────
 
+  const media: Media[] = useMemo(() => {
+    // 서버/목록/상세에 따라 키가 다를 수 있음 → 가능한 모든 후보에서 수집
+    const raw =
+      (feed as any)?.media ??
+      (feed as any)?.mediaUrls ??
+      (feed as any)?.images ??
+      (feed as any)?.files ??
+      [];
+
+    // 문자열 배열이면 { url } 객체로 매핑
+    if (typeof raw[0] === 'string') {
+      return (raw as string[]).filter(Boolean).map<Media>((url, idx) => ({
+        mediaUrl: url,
+        position: idx,
+        mediaId: `${feed?.feedId ?? 'tmp'}_${idx}`,
+        type: 'IMAGE',
+        mediaType: 'IMAGE', // mediaType 필드 추가 (필수)
+      }));
+    }
+
+    return [];
+  }, [feed]);
+
+  // ─────────────────────────────────────────────
+  // 2) 작성자 정보 안전 폴백
+  // ─────────────────────────────────────────────
+  const authorId = feed?.author?.userId ?? 0;
+  const authorName = feed?.author?.name ?? '사용자';
+  const authorProfile = feed?.author?.profileImage ?? undefined;
+  const isAuthor = authorId === userInfo?.id;
+
+  // ─────────────────────────────────────────────
+  // 3) 연결 배지 라벨 (널가드)
+  // ─────────────────────────────────────────────
+  const linkedCount = feed?.linkedUserCount ?? 0;
+  const linkedUser = Array.isArray(feed?.linkedUser) ? feed.linkedUser : [];
+  const linkedLabel = useMemo(() => {
+    const nonAuthor = linkedUser.filter((u) => !u.isAuthor);
+    const first = nonAuthor[0]?.name ?? '사용자';
+    const others = Math.max(linkedCount - 1, 0);
+    return others > 0 ? `${first} 외 ${others}명` : first;
+  }, [linkedUser, linkedCount]);
+
+  // ─────────────────────────────────────────────
+  // 4) 날짜 표시 안전 처리
+  //    - NaN년 NaN월 NaN일 방지: createdAt 존재/파싱 가능할 때만 formatDate
+  // ─────────────────────────────────────────────
+  const createdAtText = useMemo(() => {
+    const raw =
+      (feed as any)?.createdAt ??
+      (feed as any)?.created_at ??
+      (feed as any)?.createdDate ??
+      null;
+
+    if (!raw) return ''; // 값이 없으면 빈 문자열
+
+    // formatDate가 문자열/Date 모두 받는다면 그대로 전달,
+    // 아니라면 new Date로 검증 후 전달
+    const d = new Date(raw);
+    if (isNaN(d.getTime())) return '';
+    return formatDate(raw);
+  }, [feed]);
+
+  // ─────────────────────────────────────────────
+  // 5) 메뉴/삭제/신고 로직
+  // ─────────────────────────────────────────────
   const handleDelete = useCallback(() => {
     closeModal();
     openModal('deleteConfirm');
@@ -59,10 +127,9 @@ export default function FeedDetailItem({ feed }: Props) {
       await deleteFeed(feed.feedId);
       showToast('삭제 완료!', 'success');
       setTimeout(() => {
-        router.replace('/(page)/feed'); // 삭제 후 목록으로 이동
-      }, 1500);
-    } catch (err: any) {
-      console.error('피드 삭제 오류:', err);
+        router.replace('/(page)/feed');
+      }, 1200);
+    } catch {
       showToast('삭제 실패!', 'error');
     } finally {
       closeModal();
@@ -70,8 +137,11 @@ export default function FeedDetailItem({ feed }: Props) {
   }, [feed.feedId, closeModal, showToast]);
 
   return (
-    <View style={{ flex: 1 }}>
-      <BackgroundImageSlider mediaUrls={feed.media} />
+    <Wrapper>
+      <BackgroundImageSlider
+        mediaUrls={media}
+        gradient={{ top: 120 * height, bottom: 520 * height }}
+      />
 
       <Header
         isBackWhite
@@ -79,7 +149,7 @@ export default function FeedDetailItem({ feed }: Props) {
         kebabPress={() => openModal('menu')}
         style={{
           position: 'absolute',
-          top: 0,
+          top: 35,
           width: '100%',
           zIndex: 20,
           paddingHorizontal: CONTAINER_PADDING * width,
@@ -87,126 +157,116 @@ export default function FeedDetailItem({ feed }: Props) {
       />
 
       {/* 본문 */}
-      <View
-        style={{
-          paddingHorizontal: CONTAINER_PADDING * width,
-          marginBottom: 52 * width,
-          minHeight: 220 * height,
-        }}
-      >
-        {/* 작성자 정보 + 배지 */}
-        <RowWrapper>
-          <View
-            style={{
-              flexDirection: 'row',
-              alignItems: 'center',
-              marginBottom: 16,
-            }}
-          >
-            <View style={{ marginRight: 8 * width }}>
-              <ProfileImageWithFallback
-                uri={feed.author.profileImage}
-                size={36}
-              />
-            </View>
-            <StyledText>{feed.author.name}</StyledText>
+      <Body>
+        <TopRow>
+          <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+            <Link href={`/users/${authorId}`} asChild>
+              <TouchableOpacity
+                style={{ flexDirection: 'row', alignItems: 'center' }}
+              >
+                <ProfileImageWithFallback uri={authorProfile} size={36} />
+                <StyledText>{authorName}</StyledText>
+              </TouchableOpacity>
+            </Link>
 
-            {feed.linkedUserCount > 1 && (
+            {linkedCount > 1 && (
               <Badge
                 variant="gray"
-                label={`${feed.author.name} 외 ${feed.linkedUserCount - 1}명`}
+                label={linkedLabel}
                 onPress={() => openModal('feedLinked')}
               />
             )}
           </View>
+
           <HeartButton
             feedId={Number(feed.feedId)}
-            totalReactionCount={feed.totalReactionCount}
-            authorId={feed.author.userId}
+            totalReactionCount={feed.totalReactionCount ?? 0}
+            authorId={authorId}
             currentUserId={userInfo?.id}
+            flushOnExit
           />
-        </RowWrapper>
+        </TopRow>
 
-        {/* 게시물 내용 */}
         <View
-          style={{
-            paddingHorizontal: 18 * width,
-            paddingBottom: 48 * height,
-          }}
+          style={{ paddingHorizontal: 15 * width, paddingBottom: 76 * height }}
         >
           <Text
             style={{
-              color: colors.gray[400],
+              color: colors.white,
               fontSize: fontSize.md,
               fontFamily: fonts.Bold,
-              marginBottom: 8,
-              minHeight: 126 * height,
+              paddingBottom: 8 * height,
+              minHeight: 90 * height,
               maxHeight: 126 * height,
             }}
+            numberOfLines={5}
           >
-            {feed.description}
+            {feed?.description ?? ''}
           </Text>
 
-          {/* 작성 날짜 */}
           <Text
             style={{
-              color: colors.text[3],
+              color: colors.white,
               fontSize: fontSize.md,
               fontFamily: fonts.Light,
               lineHeight: lineHeight.s,
             }}
           >
-            {formatDate(feed.createdAt)}
+            {createdAtText}
           </Text>
         </View>
-      </View>
+      </Body>
 
-      {/* 유저리스트 모달 */}
+      {/* 모달들 */}
       <UserListModal
         visible={modalType === 'feedLinked'}
         title="함께 연결된 Leets"
-        list={feed.linkedUser}
+        list={linkedUser}
         onClose={closeModal}
       />
-      {/* 삭제 메뉴 모달 */}
+
       <MenuModal
         visible={modalType === 'menu'}
         isWrite={false}
         onClose={closeModal}
-        onPressFirst={() => {}} // 추후 수정하기 옵션 추가 시 사용
-        firstOptionText={isAuthor ? '수정하기' : ''}
-        secondOptionText={isAuthor ? '삭제하기' : '신고하기'}
-        onPressSecond={isAuthor ? handleDelete : handleReport}
+        isOneOption={!isAuthor}
+        firstOptionText={isAuthor ? '수정하기' : '신고하기'}
+        secondOptionText={isAuthor ? '삭제하기' : undefined}
+        onPressFirst={isAuthor ? () => {} : handleReport}
+        onPressSecond={isAuthor ? handleDelete : undefined}
       />
+
       {modalType === 'deleteConfirm' && (
         <PopupModal
-          isOpen={modalType === 'deleteConfirm'}
+          isOpen
           onRightBtn={handleConfirmDelete}
           onLeftBtn={closeModal}
           isWarning
           mainText="피드를 삭제할거야?"
           subText="삭제하면 복구할 수 없어."
-          isCancel={true}
+          isCancel
           leftBtnText="취소"
           rightBtnText="삭제할래"
         />
       )}
-      {/* {modalType === 'feedReport' && (
-        <FeedReportModal
-          isOpen={modalType === 'feedReport'}
-          onClose={closeModal}
-          onSubmit={(reason) => {
-            console.log(`신고 사유: ${reason}`);
-            closeModal();
-            showToast('신고 완료!', 'success');
-          }}
-        />
-      )} */}
-    </View>
+
+      <FeedReportModal feedId={feed.feedId} />
+    </Wrapper>
   );
 }
 
-const RowWrapper = styled.View`
+const Wrapper = styled.View`
+  width: 100%;
+  height: 100%;
+`;
+
+const Body = styled.View`
+  padding: 0 ${FEED_PADDING * width}px;
+  min-height: ${220 * height}px;
+  z-index: 10;
+`;
+
+const TopRow = styled.View`
   flex-direction: row;
   justify-content: space-between;
   align-items: center;

--- a/components/feed/FeedDetailItem.tsx
+++ b/components/feed/FeedDetailItem.tsx
@@ -20,7 +20,7 @@ import colors from '@/theme/color';
 import { useModalStore } from '@/stores/modalStore';
 import { useToastStore } from '@/stores/toastStore';
 import { useUserStore } from '@/stores/userStore';
-import FeedReportModal from '@/components/Modal/FeedReportModal';
+import FeedReportModal from '@/components/Modal/ReportModal';
 import {
   fonts,
   fontSize,
@@ -250,7 +250,7 @@ export default function FeedDetailItem({ feed }: Props) {
         />
       )}
 
-      <FeedReportModal feedId={feed.feedId} />
+      <FeedReportModal feedId={feed.feedId} type="feed" />
     </Wrapper>
   );
 }

--- a/components/feed/HeartButton.tsx
+++ b/components/feed/HeartButton.tsx
@@ -172,7 +172,7 @@ export default function HeartButton({
 
 const HeartWithBadge = styled.View`
   align-items: center;
-  padding-right: ${17 * width}px;
+  padding-right: ${10 * width}px;
 `;
 
 const Circle = styled.View`

--- a/components/feed/ProfileFeedList.tsx
+++ b/components/feed/ProfileFeedList.tsx
@@ -4,6 +4,7 @@ import useFeedList from '@/hooks/useFeedList';
 import styled from 'styled-components/native';
 import { height } from '@/theme/globalStyles';
 import { useEffect } from 'react';
+import { FEED_PADDING } from '@/constants';
 
 interface FeedListProps {
   type: 'myFeed' | 'myJoined';
@@ -46,9 +47,10 @@ export default function ProfileFeedList({
         columnWrapperStyle={{ justifyContent: 'space-between' }}
         contentContainerStyle={{
           paddingBottom: 100 * height,
+          paddingHorizontal: FEED_PADDING,
         }}
         renderItem={({ item }) => <FeedCard item={item} />}
-        showsVerticalScrollIndicator={false}
+        showsVerticalScrollIndicator
         onEndReached={loadMore}
         onEndReachedThreshold={0.5}
         refreshing={isRefreshing}

--- a/components/feed/ProfileFeedList.tsx
+++ b/components/feed/ProfileFeedList.tsx
@@ -2,7 +2,7 @@ import { FlatList } from 'react-native';
 import { FeedCard, Loading } from '@/components';
 import useFeedList from '@/hooks/useFeedList';
 import styled from 'styled-components/native';
-import { height } from '@/theme/globalStyles';
+import { height, width } from '@/theme/globalStyles';
 import { useEffect } from 'react';
 import { FEED_PADDING } from '@/constants';
 
@@ -47,7 +47,7 @@ export default function ProfileFeedList({
         columnWrapperStyle={{ justifyContent: 'space-between' }}
         contentContainerStyle={{
           paddingBottom: 100 * height,
-          paddingHorizontal: FEED_PADDING,
+          paddingHorizontal: FEED_PADDING * width,
         }}
         renderItem={({ item }) => <FeedCard item={item} />}
         showsVerticalScrollIndicator

--- a/components/feed/SearchBar.tsx
+++ b/components/feed/SearchBar.tsx
@@ -41,7 +41,7 @@ export default function SearchBar({ value, onChange }: SearchBarProps) {
 const SearchBarWrapper = styled.View`
   flex-direction: row;
   align-items: center;
-  width: ${335 * width}px;
+  width: 100%;
   height: ${38 * height}px;
   background-color: ${colors.gray[100]};
   border-radius: ${radius.xs}px;

--- a/components/feed/UserItem.tsx
+++ b/components/feed/UserItem.tsx
@@ -23,7 +23,7 @@ export default function UserItem({ user, checked, onToggle }: UserItemProps) {
     >
       <ProfileImageWithFallback uri={user.profileImage} />
       <UserName>{user.name}</UserName>
-      <CheckBox checked={checked} />
+      <CheckBox checked={checked} onPress={onToggle} />
     </Wrapper>
   );
 }

--- a/components/feed/UserListModalContent.tsx
+++ b/components/feed/UserListModalContent.tsx
@@ -25,7 +25,7 @@ export default function UserListModalContent({
       data={sortedList}
       keyExtractor={(item, index) => `${item.userId}-${index}`}
       contentContainerStyle={{ paddingBottom: 32 }}
-      showsVerticalScrollIndicator={true}
+      showsVerticalScrollIndicator={false}
       renderItem={({ item }) => (
         <View onStartShouldSetResponder={() => true}>
           <Pressable

--- a/components/leenk/CalendarButton.tsx
+++ b/components/leenk/CalendarButton.tsx
@@ -1,6 +1,8 @@
-import React, { useState } from 'react';
-import { Platform, Pressable } from 'react-native';
-import DateTimePicker from '@react-native-community/datetimepicker';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Pressable } from 'react-native';
+import DatePicker, { getFormatedDate } from 'react-native-modern-datepicker';
+import dayjs from 'dayjs';
+import styled from 'styled-components/native';
 import { CalendarIcon } from '@/assets';
 import colors from '@/theme/color';
 import {
@@ -11,42 +13,48 @@ import {
   radius,
   width,
 } from '@/theme/globalStyles';
-import styled from 'styled-components/native';
-import dayjs from 'dayjs';
-import DatePicker from 'react-native-modern-datepicker';
-import { getFormatedDate } from 'react-native-modern-datepicker';
 
 interface CalendarButtonProps {
   value?: Date | null;
   onChange?: (date: Date | null) => void;
 }
 
+type Step = 'date' | 'time' | null;
+
 export default function CalendarButton({
   value,
   onChange,
 }: CalendarButtonProps) {
-  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
-  const [step, setStep] = useState<'date' | 'time' | null>(null); // Android 전용
-  const [tempDate, setTempDate] = useState<string>(''); // YYYY-MM-DD
+  const [selectedDate, setSelectedDate] = useState<Date | null>(value ?? null);
+  const [step, setStep] = useState<Step>(null);
+  const [tempDateStr, setTempDateStr] = useState<string>('');
+  const minDateStr = useMemo(
+    () => getFormatedDate(new Date(), 'YYYY/MM/DD'),
+    [],
+  );
 
-  const handleSelectDate = (date: Date | null) => {
+  useEffect(() => {
+    if (value?.getTime() !== selectedDate?.getTime()) {
+      setSelectedDate(value ?? null);
+    }
+  }, [value]);
+
+  const commit = (date: Date | null) => {
     setSelectedDate(date);
-    onChange?.(date); // 부모로 전달
+    onChange?.(date);
   };
 
-  const handleIOSChange = (_: any, date?: Date) => {
-    if (date) handleSelectDate(date);
-    setStep(null);
-  };
-
-  const handleAndroidDate = (dateStr: string) => {
-    setTempDate(dateStr);
+  const handleSelectDate = (dateStr: string) => {
+    setTempDateStr(dateStr); // YYYY/MM/DD
     setStep('time');
   };
 
-  const handleAndroidTime = (timeStr: string) => {
-    const date = new Date(`${tempDate}T${timeStr}`);
-    handleSelectDate(date);
+  const handleSelectTime = (timeStr: string) => {
+    const result = dayjs(
+      `${tempDateStr} ${timeStr}`,
+      'YYYY/MM/DD HH:mm',
+    ).toDate();
+    commit(result);
     setStep(null);
   };
 
@@ -55,84 +63,59 @@ export default function CalendarButton({
       <Container $isFocused={!!step}>
         <StyledText selected={!!selectedDate}>
           {selectedDate
-            ? dayjs(selectedDate).format('MM월 DD일 HH시')
+            ? dayjs(selectedDate).format('MM월 DD일 HH시 mm분')
             : '모임 일시를 선택해줘'}
         </StyledText>
-
-        <Pressable
-          onPress={() => {
-            if (Platform.OS === 'ios') {
-              setStep('date');
-            } else {
-              setStep('date');
-            }
-          }}
-        >
+        <Pressable onPress={() => setStep('date')}>
           <CalendarIcon />
         </Pressable>
       </Container>
 
-      {/* iOS: native datetime picker */}
-      {Platform.OS === 'ios' && step === 'date' && (
-        <DateTimePicker
-          value={selectedDate || new Date()}
-          mode="datetime"
-          display="default"
-          onChange={handleIOSChange}
-          minimumDate={new Date()}
-        />
-      )}
-
-      {/* Android: modern-datepicker date -> time */}
-      {Platform.OS === 'android' && step === 'date' && (
+      {/* 날짜 선택 */}
+      {step === 'date' && (
         <DatePicker
           mode="calendar"
+          minimumDate={minDateStr}
+          onSelectedChange={handleSelectDate} // YYYY/MM/DD
           onDateChange={() => {}}
           onMonthYearChange={() => {}}
-          onSelectedChange={handleAndroidDate}
-          minimumDate={getFormatedDate(new Date(), 'YYYY/MM/DD')}
           options={{
             mainColor: colors.primary,
             defaultFont: fonts.Regular,
             headerFont: fonts.Bold,
           }}
           locale="en"
-          isGregorian={true}
+          isGregorian
         />
       )}
 
-      {Platform.OS === 'android' && step === 'time' && (
+      {/* 시간 선택 */}
+      {step === 'time' && (
         <DatePicker
           mode="time"
-          onTimeChange={(timeStr) => {
-            const date = dayjs(
-              `${tempDate} ${timeStr}`,
-              'YYYY-MM-DD HH:mm',
-            ).toDate();
-            setSelectedDate(date);
-            setStep(null);
-          }}
-          onDateChange={() => {}}
-          onSelectedChange={handleAndroidTime}
+          onTimeChange={handleSelectTime} // HH:mm
           minuteInterval={30}
+          onDateChange={() => {}}
+          onSelectedChange={() => {}}
           options={{
             mainColor: colors.primary,
             defaultFont: fonts.Regular,
             headerFont: fonts.Bold,
           }}
           locale="en"
-          isGregorian={true}
+          isGregorian
         />
       )}
     </>
   );
 }
 
+/* styled */
 const Container = styled.View<{ $isFocused: boolean }>`
   width: 100%;
   border-radius: ${radius.sm}px;
   padding: ${height * 12}px ${width * 12}px;
-  margin-top: ${height * 8}px;
+  margin-top: ${height * 12}px;
   border-width: ${({ $isFocused }) => ($isFocused ? 2 : 1)}px;
   border-color: ${({ $isFocused }) =>
     $isFocused ? colors.primaryLight : colors.divider[2]};

--- a/components/leenk/CalendarButton.tsx
+++ b/components/leenk/CalendarButton.tsx
@@ -16,13 +16,26 @@ import dayjs from 'dayjs';
 import DatePicker from 'react-native-modern-datepicker';
 import { getFormatedDate } from 'react-native-modern-datepicker';
 
-export default function CalendarButton() {
+interface CalendarButtonProps {
+  value?: Date | null;
+  onChange?: (date: Date | null) => void;
+}
+
+export default function CalendarButton({
+  value,
+  onChange,
+}: CalendarButtonProps) {
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const [step, setStep] = useState<'date' | 'time' | null>(null); // Android 전용
   const [tempDate, setTempDate] = useState<string>(''); // YYYY-MM-DD
 
+  const handleSelectDate = (date: Date | null) => {
+    setSelectedDate(date);
+    onChange?.(date); // 부모로 전달
+  };
+
   const handleIOSChange = (_: any, date?: Date) => {
-    if (date) setSelectedDate(date);
+    if (date) handleSelectDate(date);
     setStep(null);
   };
 
@@ -33,7 +46,7 @@ export default function CalendarButton() {
 
   const handleAndroidTime = (timeStr: string) => {
     const date = new Date(`${tempDate}T${timeStr}`);
-    setSelectedDate(date);
+    handleSelectDate(date);
     setStep(null);
   };
 
@@ -120,7 +133,7 @@ const Container = styled.View<{ $isFocused: boolean }>`
   border-radius: ${radius.sm}px;
   padding: ${height * 12}px ${width * 12}px;
   margin-top: ${height * 8}px;
-  border-width: 2px;
+  border-width: ${({ $isFocused }) => ($isFocused ? 2 : 1)}px;
   border-color: ${({ $isFocused }) =>
     $isFocused ? colors.primaryLight : colors.divider[2]};
   background-color: transparent;
@@ -130,7 +143,7 @@ const Container = styled.View<{ $isFocused: boolean }>`
 `;
 
 const StyledText = styled.Text<{ selected: boolean }>`
-  font-size: ${fontSize.md}px;
+  font-size: ${fontSize.lg}px;
   line-height: ${lineHeight.l};
   font-family: ${fonts.Regular};
   color: ${({ selected }) => (selected ? colors.black : '#B0B0B0')};

--- a/components/leenk/CalendarButton.tsx
+++ b/components/leenk/CalendarButton.tsx
@@ -13,6 +13,7 @@ import {
   radius,
   width,
 } from '@/theme/globalStyles';
+import { useToastStore } from '@/stores/toastStore';
 
 interface CalendarButtonProps {
   value?: Date | null;
@@ -25,6 +26,8 @@ export default function CalendarButton({
   value,
   onChange,
 }: CalendarButtonProps) {
+  const { showToast } = useToastStore();
+
   const [selectedDate, setSelectedDate] = useState<Date | null>(value ?? null);
   const [step, setStep] = useState<Step>(null);
   const [tempDateStr, setTempDateStr] = useState<string>('');
@@ -50,11 +53,20 @@ export default function CalendarButton({
   };
 
   const handleSelectTime = (timeStr: string) => {
-    const result = dayjs(
-      `${tempDateStr} ${timeStr}`,
-      'YYYY/MM/DD HH:mm',
-    ).toDate();
-    commit(result);
+    const selected = dayjs(`${tempDateStr} ${timeStr}`, 'YYYY/MM/DD HH:mm');
+    const now = dayjs();
+    if (selected.isSame(now, 'day') && selected.isBefore(now)) {
+      const minutesToAdd = 30 - (now.minute() % 30);
+      const rounded = now
+        .add(minutesToAdd === 30 ? 0 : minutesToAdd, 'minute')
+        .second(0)
+        .millisecond(0);
+
+      showToast('현재 시간 이후로 선택해줘!', 'error');
+      commit(rounded.toDate());
+    } else {
+      commit(selected.toDate());
+    }
     setStep(null);
   };
 

--- a/components/leenk/LeenkImagePicker.tsx
+++ b/components/leenk/LeenkImagePicker.tsx
@@ -92,7 +92,7 @@ const ImageGrid = styled.View`
 
 const SquareImage = styled.Pressable<{ $selected: boolean }>`
   background-color: ${colors.gray[10]};
-  border-radius: ${radius.lg}px;
+  border-radius: ${radius.md}px;
   align-items: center;
   justify-content: center;
   overflow: hidden;

--- a/components/leenk/LeenkImagePicker.tsx
+++ b/components/leenk/LeenkImagePicker.tsx
@@ -87,12 +87,12 @@ const Container = styled.View`
 const ImageGrid = styled.View`
   flex-direction: row;
   flex-wrap: wrap;
-  gap: ${width * 8}px;
+  gap: ${width * 4}px;
 `;
 
 const SquareImage = styled.Pressable<{ $selected: boolean }>`
   background-color: ${colors.gray[10]};
-  border-radius: ${radius.md}px;
+  border-radius: ${radius.lg}px;
   align-items: center;
   justify-content: center;
   overflow: hidden;

--- a/constants/dimension.constants.ts
+++ b/constants/dimension.constants.ts
@@ -5,6 +5,8 @@ export const NUM_COLUMNS = 3;
 export const ITEM_MARGIN = 4;
 export const CONTAINER_PADDING = 16;
 
+export const FEED_PADDING = 20;
+
 export const IMAGE_SIZE =
   (SCREEN_WIDTH - CONTAINER_PADDING * 2 - ITEM_MARGIN * (NUM_COLUMNS - 1)) /
   NUM_COLUMNS;

--- a/ios/Leenk.xcodeproj/project.pbxproj
+++ b/ios/Leenk.xcodeproj/project.pbxproj
@@ -395,7 +395,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.leetsmakers.leenk;
-				PRODUCT_NAME = "Leenk";
+				PRODUCT_NAME = Leenk;
 				SWIFT_OBJC_BRIDGING_HEADER = "Leenk/Leenk-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -426,7 +426,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.leetsmakers.leenk;
-				PRODUCT_NAME = "Leenk";
+				PRODUCT_NAME = Leenk;
 				SWIFT_OBJC_BRIDGING_HEADER = "Leenk/Leenk-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2193,6 +2193,29 @@ PODS:
     - ReactCommon/turbomodule/core
     - RNCKakaoCore
     - Yoga
+  - RNDateTimePicker (8.4.3):
+    - DoubleConversion
+    - glog
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsc
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - RNFBApp (22.4.0):
     - Firebase/CoreOnly (= 11.15.0)
     - React-Core
@@ -2567,6 +2590,7 @@ DEPENDENCIES:
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - "RNCKakaoCore (from `../node_modules/@react-native-kakao/core`)"
   - "RNCKakaoUser (from `../node_modules/@react-native-kakao/user`)"
+  - "RNDateTimePicker (from `../node_modules/@react-native-community/datetimepicker`)"
   - "RNFBApp (from `../node_modules/@react-native-firebase/app`)"
   - "RNFBMessaging (from `../node_modules/@react-native-firebase/messaging`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
@@ -2814,6 +2838,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-kakao/core"
   RNCKakaoUser:
     :path: "../node_modules/@react-native-kakao/user"
+  RNDateTimePicker:
+    :path: "../node_modules/@react-native-community/datetimepicker"
   RNFBApp:
     :path: "../node_modules/@react-native-firebase/app"
   RNFBMessaging:
@@ -2954,6 +2980,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: f4b48b7eb2ae9296be4df608ff60c1b12a469b7a
   RNCKakaoCore: e1ace881c26bd8ad0d65e00b761d96421e29f50e
   RNCKakaoUser: 7b1d51afea54fd2e7ed190299d6006f507c6cde5
+  RNDateTimePicker: ad12f81f5fa982b51f972571fab5872f2c7c8a13
   RNFBApp: 12884d3bf9b3a0223efe4a0adce516edf72c4102
   RNFBMessaging: e954bfb053a5c6bb10b26bae4bbc58a4edd41131
   RNGestureHandler: 6bf8b210cbad95ced45f3f9b8df05924b3a97300

--- a/stores/feedWriteStore.ts
+++ b/stores/feedWriteStore.ts
@@ -1,16 +1,23 @@
 import { create } from 'zustand';
-import { FeedConnectedUser, Media } from '@/types/feed';
+import { FeedConnectedUser, FeedDetail, Media } from '@/types/feed';
 
 export interface SelectedImage {
   uri: string;
   filename: string;
 }
 
+export type EditImage =
+  | { type: 'create'; uri: string; filename: string; tempId: string } // 피드 글쓰기용 로컬
+  | { type: 'edit'; id: number; uri: string }; // 수정용
+
 interface FeedWriteStore {
   selectedImages: SelectedImage[];
   users: FeedConnectedUser[];
   mediaUrls: Media[];
   description: string;
+
+  isEdit: boolean; // 수정 모드 여부
+  feedId?: number;
 
   setSelectedImages: (images: SelectedImage[]) => void;
   addSelectedImage: (image: SelectedImage) => void;
@@ -26,14 +33,30 @@ interface FeedWriteStore {
 
   setDescription: (text: string) => void;
 
+  startCreate: () => void;
+  startEditFromDetail: (d: FeedDetail) => void;
+  buildUpdatePayload: (
+    uploadLocal: (file: {
+      uri: string;
+      filename: string;
+    }) => Promise<{ fileId: number }>,
+  ) => Promise<{
+    content: string;
+    connectedUserIds: number[];
+    images: { id?: number; fileId?: number; order: number }[];
+  }>;
+
   reset: () => void;
 }
 
-export const useFeedWriteStore = create<FeedWriteStore>((set) => ({
+export const useFeedWriteStore = create<FeedWriteStore>((set, get) => ({
   selectedImages: [],
   users: [],
   mediaUrls: [],
   description: '',
+
+  isEdit: false,
+  feedId: undefined,
 
   setSelectedImages: (images) => set({ selectedImages: images }),
   addSelectedImage: (image) =>
@@ -67,6 +90,72 @@ export const useFeedWriteStore = create<FeedWriteStore>((set) => ({
 
   setDescription: (text) => set({ description: text }),
 
+  /** 새 글쓰기 진입 */
+  startCreate: () =>
+    set({
+      isEdit: false,
+      feedId: undefined,
+      selectedImages: [],
+      users: [],
+      mediaUrls: [],
+      description: '',
+    }),
+
+  /** 수정 진입: 상세 응답으로 프리필 */
+  startEditFromDetail: (d) =>
+    set({
+      isEdit: true,
+      feedId: d.feedId,
+      // 서버 이미지들을 mediaUrls로만 세팅 (기존 변수명 유지)
+      mediaUrls: d.media.map((m, idx) => ({
+        mediaUrl: m.mediaUrl,
+        position: m.position ?? idx,
+        mediaType: m.mediaType,
+      })),
+      users: d.linkedUser,
+      description: d.description ?? '',
+      // 로컬 선택은 비움(사용자가 추가하면 selectedImages에 쌓임)
+      selectedImages: [],
+    }),
+
+  /** 저장(PATCH) 바디 생성: mediaUrls는 id로, selectedImages는 업로드 후 fileId로 */
+  buildUpdatePayload: async (uploadLocal) => {
+    const { mediaUrls, selectedImages, users, description } = get();
+
+    // 1) 로컬 이미지 업로드
+    const uploaded = await Promise.all(
+      selectedImages.map(async (img) => {
+        const { fileId } = await uploadLocal({
+          uri: img.uri,
+          filename: img.filename,
+        });
+        return { fileId };
+      }),
+    );
+
+    // 2) 전송 순서 결정: mediaUrls(기존) → selectedImages(신규)
+    const images = [
+      ...mediaUrls.map((m, idx) => ({ id: m.position, order: idx })), // 기존
+      ...uploaded.map((u, i) => ({
+        fileId: u.fileId,
+        order: mediaUrls.length + i,
+      })), // 신규
+    ];
+
+    return {
+      content: description,
+      connectedUserIds: users.map((u) => u.userId),
+      images,
+    };
+  },
+
   reset: () =>
-    set({ selectedImages: [], users: [], mediaUrls: [], description: '' }),
+    set({
+      selectedImages: [],
+      users: [],
+      mediaUrls: [],
+      description: '',
+      isEdit: false,
+      feedId: undefined,
+    }),
 }));

--- a/stores/userStore.ts
+++ b/stores/userStore.ts
@@ -1,15 +1,5 @@
 import { create } from 'zustand';
-
-export interface UserInfo {
-  id: number;
-  cardinal: number;
-  name: string;
-  position: 'FE' | 'BE' | 'D' | 'PM';
-  profileImage: string;
-  kakaoTalkId: string;
-  introduction: string;
-  mbti: string;
-}
+import { UserInfo } from '@/hooks/useUserInfo';
 
 interface UserStoreState {
   userInfo: UserInfo | null;


### PR DESCRIPTION
- closed #38 

## 📝 Work Description

- 피드 수정하기 플로우 추가 
- 스크롤바 추가 
- 피드신고 모달 -> 공통 신고 모달로 리팩토링(ReportModal)
- 링크 글쓰기 ui 자잘한 것 수정 ( 날짜 선택 라이브러리 통일, input / textarea 스타일 수정, 모달 ui 수정) 
- 링크 글쓰기 유효성 검사 추가 


## 📸 Screenshot
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img width="300" src="이미지 주소" /> -->

### 피드 수정 플로우 
https://github.com/user-attachments/assets/bafc44c4-7c8a-47b9-8d55-0d596f419df8


### 스크롤바 추가한 것 
<img width="564" height="1062" alt="image" src="https://github.com/user-attachments/assets/2579cf40-5edf-4e88-b57c-de4f8d1b89c4" />

### 링크 글 쓰기 페이지 ui 수정( input placeholder 폰트가 적용이 안된 것 같아서 수정.. 등) 
<img width="564" height="1062" alt="image" src="https://github.com/user-attachments/assets/10391f3a-99b2-42a6-a7b5-6f165192485d" />




## 🚨Issue
피드 수정하기 눌렀다가 다시 뒤로간 후 피드 글쓰기 페이지로 갔을 때 피드 수정하기의 컨텐츠들이 그대로 남아있는 문제가 있습니다.. 
전역상태관리 때문에 그런 것 같은데 다음 이슈에서 수정해보겟ㅆ습니다.. 

<img width="564" height="1062" alt="image" src="https://github.com/user-attachments/assets/09d44613-49d8-4631-9a57-93b322ecb6e3" />

## 📣 To Reviewers
1)피드 수정 api는 아직 백엔드 머지가 안된 것 같아서 다음 이슈에서 .. 

2)스크롤바는 컴포넌트로 따로 분리하지 않고 구현했습니다! 

FlatList 내의 contentContainerStyle에 paddingHorizontal을 추가하고 , 상위 태그에 있던 `paddingHorizontal`을 삭제하면 되더라구요!
그리고 헤더 및 다른 요소는 View태그로 감싸서 다시 패딩을 줬습니당..
 
제가 링크, 알림 페이지까지 수정하긴 했는데 알림 페이지에서 더보기 눌렀을 때 나오는 모달에서는 ui 수정도 좀 필요한 것 같아서 이 부분만.. 나중에  같이 수정해주시면 좋을 것 같습니다! 

3)그리고 상세 피드에서 수직 스크롤 구현 시도하느라 `FeedDetailItem` 컴포넌트가 수정된 게 있는데 일단 이 파일은 무시해주세요.. 


4)`FeedReportModal`을 `ReportModal`로 바꾼 후 타입을 추가해서 피드인지 링크인지 구분해 재사용할 수 있도록 수정했고, 링크페이지에서도 수정은 해놨는데 화면상으로 확인을 못해서.. 링크 신고 api 연결하실 때 확인 한번 부탁드립니다! 


**여기서 다 구현하기엔 좀 많아질 것 같아서 다음 이슈에서 진 짜 입력창 열렸을 때 버튼 위치 이상한 부분을 수정해보겠습니다.. + 상세 피드 제스쳐 뒤로가기** 

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 피드 편집 모드(기존 게시물 불러오기·미디어 병합·수정 확정 흐름) 추가.
  - 신고 모달이 피드/링크 공용으로 확장.
  - 캘린더 버튼이 제어형으로 개선되어 날짜·시간 2단계 선택 지원.

- 스타일
  - FEED_PADDING 기준으로 전반 가로 여백 정비 및 여러 리스트에서 스크롤바 노출.
  - 검색바 풀폭(100%) 적용, 일부 아이콘·간격·타이포 개선.

- 개선
  - 체크박스 이벤트에 이벤트 인자 전달 및 전파 차단.
  - 프로필·리스트 컴포넌트의 합계 반영 콜백 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->