### PR TITLE
LNK-M-21 Leenk API 연결

### DIFF
--- a/api/api.ts
+++ b/api/api.ts
@@ -22,13 +22,19 @@ const refreshAccessToken = async () => {
   const refreshToken = await getRefreshToken();
   if (!refreshToken) throw new Error('No refresh token');
 
-  const response = await axios.post(`${BASE_URL}/refresh`, { refreshToken });
-  const { access_token, refresh_token } = response.data.data;
+  try {
+    const response = await axios.post(`${BASE_URL}/refresh`, { refreshToken });
+    const { access_token, refresh_token } = response.data.data;
 
-  await saveAccessToken(access_token);
-  await saveRefreshToken(refresh_token);
+    await saveAccessToken(access_token);
+    await saveRefreshToken(refresh_token);
 
-  return access_token;
+    return access_token;
+  } catch (error: any) {
+    console.error('[refreshAccessToken] 토큰 갱신 실패:', error.response?.data);
+    await clearAllTokens();
+    throw error;
+  }
 };
 
 // 요청 인터셉터

--- a/api/api.ts
+++ b/api/api.ts
@@ -24,14 +24,15 @@ const refreshAccessToken = async () => {
 
   try {
     const response = await axios.post(`${BASE_URL}/refresh`, { refreshToken });
-    const { access_token, refresh_token } = response.data.data;
 
-    await saveAccessToken(access_token);
-    await saveRefreshToken(refresh_token);
+    const { accessToken, refreshToken: newRefreshToken } = response.data.data;
 
-    return access_token;
-  } catch (error: any) {
-    console.error('[refreshAccessToken] 토큰 갱신 실패:', error.response?.data);
+    await saveAccessToken(accessToken);
+    await saveRefreshToken(newRefreshToken);
+
+    return accessToken;
+  } catch (error) {
+    console.error('[refreshAccessToken] 토큰 갱신 실패:', error);
     await clearAllTokens();
     throw error;
   }
@@ -66,7 +67,6 @@ api.interceptors.response.use(
   (res) => res,
   async (error) => {
     const originalRequest = error.config;
-
     if (error.response?.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true;
 

--- a/api/leenk/leenk.del.api.ts
+++ b/api/leenk/leenk.del.api.ts
@@ -1,0 +1,42 @@
+import api from '@/api/api';
+import { ApiResponse } from '@/api/api-type';
+
+// 링크 나가기
+export const leaveLeenk = async (leenkId: number) => {
+  const res = await api.delete<ApiResponse<string>>(
+    `/leenks/${leenkId}/participant`,
+  );
+
+  if (__DEV__) {
+    console.log(`링크 나가기(${leenkId}):`, res.data.data);
+  }
+
+  return res.data.data;
+};
+
+// 링크 삭제하기
+export const deleteLeenk = async (leenkId: number) => {
+  const res = await api.delete<ApiResponse<string>>(`/leenks/${leenkId}`);
+
+  if (__DEV__) {
+    console.log(`링크 삭제하기(${leenkId}):`, res.data.data);
+  }
+
+  return res.data.data;
+};
+
+// 링크 참여자 내보내기
+export const kickLeenkParticipants = async (
+  leenkId: number,
+  participantId: number,
+) => {
+  const res = await api.delete<ApiResponse<string>>(
+    `/leenks/${leenkId}/participants/${participantId}`,
+  );
+
+  if (__DEV__) {
+    console.log(`링크 참여자 내보내기(${leenkId}):`, res.data.data);
+  }
+
+  return res.data.data;
+};

--- a/api/leenk/leenk.get.api.ts
+++ b/api/leenk/leenk.get.api.ts
@@ -6,6 +6,7 @@ import {
 import api from '@/api/api';
 import { ApiResponse } from '@/api/api-type';
 
+// 링크 전체 조회
 export const getLeenkList = async (
   pageNumber: number,
   pageSize: number,
@@ -19,9 +20,28 @@ export const getLeenkList = async (
     },
   });
 
+  // if (__DEV__) {
+  //   console.log('링크 전체 조회:', res.data);
+  //   console.log('first leenk:', res.data.data.leenks[0]);
+  // }
+
+  return res.data;
+};
+
+// 내가 참여한 링크 조회
+export const getMyLeenkList = async (pageNumber: number, pageSize: number) => {
+  const res = await api.get<ApiResponse<LeenkListResponse>>(
+    '/leenks/participated',
+    {
+      params: {
+        pageNumber,
+        pageSize,
+      },
+    },
+  );
+
   if (__DEV__) {
-    console.log('링크 전체 조회:', res.data);
-    console.log('first leenk:', res.data.data.leenks[0]);
+    console.log('참여한 링크 조회:', res.data);
   }
 
   return res.data;

--- a/api/leenk/leenk.get.api.ts
+++ b/api/leenk/leenk.get.api.ts
@@ -25,7 +25,7 @@ export const getLeenkList = async (
   //   console.log('first leenk:', res.data.data.leenks[0]);
   // }
 
-  return res.data;
+  return res.data.data;
 };
 
 // 내가 참여한 링크 조회
@@ -44,7 +44,7 @@ export const getMyLeenkList = async (pageNumber: number, pageSize: number) => {
   //   console.log('참여한 링크 조회:', res.data);
   // }
 
-  return res.data;
+  return res.data.data;
 };
 
 // 링크 상세 조회

--- a/api/leenk/leenk.get.api.ts
+++ b/api/leenk/leenk.get.api.ts
@@ -11,7 +11,7 @@ export const getLeenkList = async (
   pageSize: number,
   status: 'ALL' | 'OPEN' | 'CLOSED' = 'ALL',
 ) => {
-  const res = await api.get<LeenkListResponse>('/leenks', {
+  const res = await api.get<ApiResponse<LeenkListResponse>>('/leenks', {
     params: {
       status,
       pageNumber,
@@ -21,6 +21,7 @@ export const getLeenkList = async (
 
   if (__DEV__) {
     console.log('링크 전체 조회:', res.data);
+    console.log('first leenk:', res.data.data.leenks[0]);
   }
 
   return res.data;

--- a/api/leenk/leenk.get.api.ts
+++ b/api/leenk/leenk.get.api.ts
@@ -1,0 +1,53 @@
+import {
+  LeenkDetail,
+  LeenkListResponse,
+  LeenkParticipantsData,
+} from '@/types/leenk';
+import api from '../api';
+
+interface ApiResponse<T> {
+  code: number;
+  message: string;
+  data: T;
+}
+
+export const getLeenkList = async (
+  pageNumber: number,
+  pageSize: number,
+  status: 'ALL' | 'OPEN' | 'CLOSED' = 'ALL',
+) => {
+  const res = await api.get<LeenkListResponse>('/leenks', {
+    params: {
+      status,
+      pageNumber,
+      pageSize,
+    },
+  });
+
+  if (__DEV__) {
+    console.log('링크 전체 조회:', res.data);
+  }
+
+  return res.data;
+};
+
+// 링크 상세 조회
+export const getLeenkDetail = async (leenkId: number) => {
+  const res = await api.get<ApiResponse<LeenkDetail>>(`/leenks/${leenkId}`);
+
+  if (__DEV__) {
+    console.log(`링크 상세 조회(${leenkId}):`, res.data.data);
+  }
+
+  return res.data.data;
+};
+
+// 링크 참여자 목록 조회
+export const getLeenkParticipants = async (leenkId: number) => {
+  const res = await api.get<ApiResponse<LeenkParticipantsData>>(
+    `/leenks/${leenkId}/participants`,
+  );
+  if (__DEV__)
+    console.log(`참여자 목록(${leenkId}):`, res.data.data.participants);
+  return res.data.data.participants;
+};

--- a/api/leenk/leenk.get.api.ts
+++ b/api/leenk/leenk.get.api.ts
@@ -3,13 +3,8 @@ import {
   LeenkListResponse,
   LeenkParticipantsData,
 } from '@/types/leenk';
-import api from '../api';
-
-interface ApiResponse<T> {
-  code: number;
-  message: string;
-  data: T;
-}
+import api from '@/api/api';
+import { ApiResponse } from '@/api/api-type';
 
 export const getLeenkList = async (
   pageNumber: number,

--- a/api/leenk/leenk.get.api.ts
+++ b/api/leenk/leenk.get.api.ts
@@ -40,9 +40,9 @@ export const getMyLeenkList = async (pageNumber: number, pageSize: number) => {
     },
   );
 
-  if (__DEV__) {
-    console.log('참여한 링크 조회:', res.data);
-  }
+  // if (__DEV__) {
+  //   console.log('참여한 링크 조회:', res.data);
+  // }
 
   return res.data;
 };

--- a/api/leenk/leenk.patch.api.ts
+++ b/api/leenk/leenk.patch.api.ts
@@ -1,0 +1,2 @@
+import api from '@/api/api';
+import { ApiResponse } from '@/api/api-type';

--- a/api/leenk/leenk.patch.api.ts
+++ b/api/leenk/leenk.patch.api.ts
@@ -1,2 +1,19 @@
 import api from '@/api/api';
 import { ApiResponse } from '@/api/api-type';
+import { UpdateLeenkPayload } from '@/types/leenk';
+
+export const updateLeenk = async (
+  leenkId: number,
+  payload: UpdateLeenkPayload,
+) => {
+  const res = await api.patch<ApiResponse<string>>(
+    `/leenks/${leenkId}`,
+    payload,
+  );
+
+  if (__DEV__) {
+    console.log(`링크 수정(${leenkId}) payload:`, payload);
+    console.log(`링크 수정(${leenkId}) response:`, res.data);
+  }
+  return res.data;
+};

--- a/api/leenk/leenk.post.api.ts
+++ b/api/leenk/leenk.post.api.ts
@@ -42,23 +42,23 @@ export const participantLeenk = async (leenkId: number) => {
   return res.data.data;
 };
 
-// 링크 모집 종료
+// 링크 모임 종료(링크 종료)
 export const finishLeenk = async (leenkId: number) => {
   const res = await api.post<ApiResponse<string>>(`/leenks/${leenkId}/finish`);
 
   if (__DEV__) {
-    console.log(`링크 모집 종료(${leenkId}):`, res.data.data);
+    console.log(`링크 모임 종료(${leenkId}):`, res.data.data);
   }
 
   return res.data.data;
 };
 
-// 링크 마감(모집 완료)
+// 링크 모집 종료
 export const closeLeenk = async (leenkId: number) => {
   const res = await api.post<ApiResponse<string>>(`/leenks/${leenkId}/close`);
 
   if (__DEV__) {
-    console.log(`링크 마감(${leenkId}):`, res.data.data);
+    console.log(`링크 모집 종료(${leenkId}):`, res.data.data);
   }
 
   return res.data.data;

--- a/api/leenk/leenk.post.api.ts
+++ b/api/leenk/leenk.post.api.ts
@@ -1,0 +1,2 @@
+import api from '@/api/api';
+import { ApiResponse } from '@/api/api-type';

--- a/api/leenk/leenk.post.api.ts
+++ b/api/leenk/leenk.post.api.ts
@@ -1,2 +1,60 @@
 import api from '@/api/api';
 import { ApiResponse } from '@/api/api-type';
+import { UpdateLeenkPayload } from '@/types/leenk';
+
+// 링크 게시물 작성
+export const createLeenk = async (payload: UpdateLeenkPayload) => {
+  const res = await api.post<ApiResponse<string>>(`/leenks`, payload);
+
+  if (__DEV__) {
+    console.log(`링크 게시물 생성 payload:`, payload);
+    console.log(`링크 게시물 생성 response:`, res.data);
+  }
+  return res.data;
+};
+
+// 링크 신고하기
+export const reportLeenk = async (leenkId: number) => {
+  const res = await api.post<ApiResponse<string>>(`/leenks/${leenkId}/reports`);
+
+  if (__DEV__) {
+    console.log(`링크 신고(${leenkId}):`, res.data.data);
+  }
+
+  return res.data.data;
+};
+
+// 링크 참여하기
+export const participantLeenk = async (leenkId: number) => {
+  const res = await api.post<ApiResponse<string>>(
+    `/leenks/${leenkId}/participant`,
+  );
+
+  if (__DEV__) {
+    console.log(`링크 참여(${leenkId}):`, res.data.data);
+  }
+
+  return res.data.data;
+};
+
+// 링크 모집 종료
+export const finishLeenk = async (leenkId: number) => {
+  const res = await api.post<ApiResponse<string>>(`/leenks/${leenkId}/finish`);
+
+  if (__DEV__) {
+    console.log(`링크 모집 종료(${leenkId}):`, res.data.data);
+  }
+
+  return res.data.data;
+};
+
+// 링크 마감(모집 완료)
+export const closeLeenk = async (leenkId: number) => {
+  const res = await api.post<ApiResponse<string>>(`/leenks/${leenkId}/close`);
+
+  if (__DEV__) {
+    console.log(`링크 마감(${leenkId}):`, res.data.data);
+  }
+
+  return res.data.data;
+};

--- a/api/leenk/leenk.post.api.ts
+++ b/api/leenk/leenk.post.api.ts
@@ -14,8 +14,13 @@ export const createLeenk = async (payload: UpdateLeenkPayload) => {
 };
 
 // 링크 신고하기
-export const reportLeenk = async (leenkId: number) => {
-  const res = await api.post<ApiResponse<string>>(`/leenks/${leenkId}/reports`);
+export const reportLeenk = async (leenkId: number, report: string) => {
+  const res = await api.post<ApiResponse<string>>(
+    `/leenks/${leenkId}/reports`,
+    {
+      report,
+    },
+  );
 
   if (__DEV__) {
     console.log(`링크 신고(${leenkId}):`, res.data.data);

--- a/app.config.ts
+++ b/app.config.ts
@@ -23,6 +23,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     infoPlist: {
       NSPhotoLibraryUsageDescription:
         '사진을 선택하려면 접근 권한이 필요합니다.',
+      CFBundleURLTypes: [{ CFBundleURLSchemes: ['leenk'] }],
     },
     googleServicesFile: './GoogleService-Info.plist',
   },
@@ -31,6 +32,14 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     package: 'com.leetsmakers.leenk',
     googleServicesFile: './google-services.json',
     edgeToEdgeEnabled: true,
+    intentFilters: [
+      {
+        action: 'VIEW',
+        autoVerify: false,
+        data: [{ scheme: 'leenk' }],
+        category: ['BROWSABLE', 'DEFAULT'],
+      },
+    ],
     adaptiveIcon: {
       // foregroundImage: './assets/images/ic_logo_round.png',
       // backgroundColor: '#ffffff',

--- a/app/(page)/leenk.tsx
+++ b/app/(page)/leenk.tsx
@@ -122,7 +122,7 @@ export default function LeenkPage() {
         />
       </View>
 
-      <List
+      <LeenkList
         data={data}
         keyExtractor={(item) => String(item.leenkId)}
         renderItem={({ item }) => <LeenkListItem item={item} />}
@@ -135,40 +135,19 @@ export default function LeenkPage() {
         onMomentumScrollBegin={() => {
           onEndReachedCalledDuringMomentum.current = false;
         }}
-        ListFooterComponent={
-          loading ? (
-            <FooterLoading />
-          ) : !hasMore ? (
-            <FooterEnd></FooterEnd>
-          ) : null
-        }
+        ListFooterComponent={loading ? <View /> : !hasMore ? <View /> : null}
       />
     </ContainerWithNoPadding>
   );
 }
 
-const List = styled.FlatList.attrs({
+export const LeenkList = styled.FlatList.attrs({
   contentContainerStyle: {
     paddingBottom: height * 20,
     paddingHorizontal: FEED_PADDING * width,
   },
 })`` as unknown as typeof import('react-native').FlatList<Leenk>;
 
-const Separator = styled.View`
+export const Separator = styled.View`
   height: ${height * 8}px;
-`;
-
-// TODO: 마지막 게시물 표시 변경
-const FooterLoading = styled.ActivityIndicator.attrs({
-  size: 'small',
-  color: colors.primary ?? '#888',
-})`
-  margin: ${height * 8}px 0;
-`;
-
-const FooterEnd = styled.Text`
-  text-align: center;
-  color: ${colors.text?.[3] ?? '#999'};
-  padding: ${height * 8}px 0;
-  font-size: 12px;
 `;

--- a/app/(page)/leenk.tsx
+++ b/app/(page)/leenk.tsx
@@ -27,8 +27,12 @@ export default function LeenkPage() {
   const [refreshing, setRefreshing] = useState(false);
   const [hasMore, setHasMore] = useState(true);
 
-  const { userInfo: fetchedUserInfo } = useUserInfo();
+  const { userInfo: fetchedUserInfo, refetch } = useUserInfo();
   const { userInfo, setUserInfo } = useUserStore();
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
 
   useEffect(() => {
     if (fetchedUserInfo && !userInfo) {

--- a/app/(page)/leenk.tsx
+++ b/app/(page)/leenk.tsx
@@ -1,17 +1,79 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components/native';
 import colors from '@/theme/color';
 import { width, height } from '@/theme/globalStyles';
 import { Header } from '@/components';
 import TabMenu from '@/components/common/TabMenu';
 import LeenkListItem from '@/components/leenk/LeenkListItem';
-import { mockLeenkData } from '@/constants/mockUserData';
 import { ContainerWithNoPadding } from '../account/my-feed';
 import { View } from 'react-native';
 import { FEED_PADDING } from '@/constants';
 
+import { getLeenkList } from '@/api/leenk/leenk.get.api';
+import { Leenk } from '@/types/leenk';
+
+const PAGE_SIZE = 10;
+const tabToStatus = (tab: 'all' | 'open' | 'close') =>
+  tab === 'all' ? 'ALL' : tab === 'open' ? 'OPEN' : 'CLOSED';
+
 export default function LeenkPage() {
-  const [tab, setTab] = useState<'all' | 'recruiting' | 'completed'>('all');
+  const [tab, setTab] = useState<'all' | 'open' | 'close'>('all');
+
+  // list / paging states
+  const [data, setData] = useState<Leenk[]>([]);
+  const [page, setPage] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+
+  // prevent duplicated calls on momentum
+  const onEndReachedCalledDuringMomentum = useRef(false);
+
+  // fetch one page
+  const loadPage = async (nextPage: number, replace = false) => {
+    if (loading) return;
+    setLoading(true);
+    try {
+      const status = tabToStatus(tab);
+      const res = await getLeenkList(nextPage, PAGE_SIZE, status); // LeenkListResponse
+      const pageItems = res.leenks ?? [];
+      const reachedEnd = pageItems.length < PAGE_SIZE; // infer end by size
+
+      setData((prev) => (replace ? pageItems : [...prev, ...pageItems]));
+      setHasMore(!reachedEnd);
+      setPage(nextPage);
+    } catch (e) {
+      if (__DEV__) console.warn('Failed to fetch leenks:', e);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  };
+
+  // initial + tab change -> reset & fetch first page
+  useEffect(() => {
+    setData([]);
+    setHasMore(true);
+    setPage(0);
+    loadPage(0, true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tab]);
+
+  // pull-to-refresh
+  const onRefresh = async () => {
+    setRefreshing(true);
+    setHasMore(true);
+    await loadPage(0, true);
+  };
+
+  // infinite scroll
+  const onEndReached = () => {
+    if (onEndReachedCalledDuringMomentum.current) return;
+    if (!loading && hasMore) {
+      onEndReachedCalledDuringMomentum.current = true;
+      loadPage(page + 1);
+    }
+  };
 
   return (
     <ContainerWithNoPadding>
@@ -21,32 +83,33 @@ export default function LeenkPage() {
           type="leenk"
           activeTab={tab}
           onTabChange={(newTab: string) => {
-            if (
-              newTab === 'all' ||
-              newTab === 'recruiting' ||
-              newTab === 'completed'
-            ) {
+            if (newTab === 'all' || newTab === 'open' || newTab === 'close') {
               setTab(newTab);
             }
           }}
         />
       </View>
+
       <List
-        data={mockLeenkData}
-        keyExtractor={(item) => item.id}
-        renderItem={({ item }) => (
-          <LeenkListItem
-            id={item.id}
-            title={item.title}
-            date={item.date}
-            people={item.people}
-            name={item.name}
-            leenkImageUri={item.leenkImageUri}
-            profileImageUri={item.profileImageUri}
-          />
-        )}
+        data={data}
+        keyExtractor={(item) => String(item.leenkId)}
+        renderItem={({ item }) => <LeenkListItem item={item} />}
         ItemSeparatorComponent={() => <Separator />}
         showsVerticalScrollIndicator
+        refreshing={refreshing}
+        onRefresh={onRefresh}
+        onEndReachedThreshold={0.6}
+        onEndReached={onEndReached}
+        onMomentumScrollBegin={() => {
+          onEndReachedCalledDuringMomentum.current = false;
+        }}
+        ListFooterComponent={
+          loading ? (
+            <FooterLoading />
+          ) : !hasMore ? (
+            <FooterEnd>끝이에요</FooterEnd>
+          ) : null
+        }
       />
     </ContainerWithNoPadding>
   );
@@ -57,8 +120,23 @@ const List = styled.FlatList.attrs({
     paddingBottom: height * 20,
     paddingHorizontal: FEED_PADDING * width,
   },
-})``;
+  // NOTE: keep default styles
+})`` as unknown as typeof import('react-native').FlatList<Leenk>;
 
 const Separator = styled.View`
   height: ${height * 8}px;
+`;
+
+const FooterLoading = styled.ActivityIndicator.attrs({
+  size: 'small',
+  color: colors.primary ?? '#888',
+})`
+  margin: ${height * 8}px 0;
+`;
+
+const FooterEnd = styled.Text`
+  text-align: center;
+  color: ${colors.text?.[3] ?? '#999'};
+  padding: ${height * 8}px 0;
+  font-size: 12px;
 `;

--- a/app/(page)/leenk.tsx
+++ b/app/(page)/leenk.tsx
@@ -19,25 +19,24 @@ const tabToStatus = (tab: 'all' | 'open' | 'close') =>
 export default function LeenkPage() {
   const [tab, setTab] = useState<'all' | 'open' | 'close'>('all');
 
-  // list / paging states
   const [data, setData] = useState<Leenk[]>([]);
   const [page, setPage] = useState(0);
   const [loading, setLoading] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [hasMore, setHasMore] = useState(true);
 
-  // prevent duplicated calls on momentum
+  // 중복 호출 방지
   const onEndReachedCalledDuringMomentum = useRef(false);
 
-  // fetch one page
+  // 첫 페이지 로드
   const loadPage = async (nextPage: number, replace = false) => {
     if (loading) return;
     setLoading(true);
     try {
       const status = tabToStatus(tab);
-      const res = await getLeenkList(nextPage, PAGE_SIZE, status); // LeenkListResponse
+      const res = await getLeenkList(nextPage, PAGE_SIZE, status);
       const pageItems = res.data.leenks ?? [];
-      const reachedEnd = pageItems.length < PAGE_SIZE; // infer end by size
+      const reachedEnd = pageItems.length < PAGE_SIZE;
 
       setData((prev) => (replace ? pageItems : [...prev, ...pageItems]));
       setHasMore(!reachedEnd);
@@ -50,23 +49,22 @@ export default function LeenkPage() {
     }
   };
 
-  // initial + tab change -> reset & fetch first page
+  // 초기화 및 탭 관리
   useEffect(() => {
     setData([]);
     setHasMore(true);
     setPage(0);
     loadPage(0, true);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tab]);
 
-  // pull-to-refresh
+  // 스크롤 당겨서 재호출
   const onRefresh = async () => {
     setRefreshing(true);
     setHasMore(true);
     await loadPage(0, true);
   };
 
-  // infinite scroll
+  // 무한스크롤
   const onEndReached = () => {
     if (onEndReachedCalledDuringMomentum.current) return;
     if (!loading && hasMore) {
@@ -126,6 +124,7 @@ const Separator = styled.View`
   height: ${height * 8}px;
 `;
 
+// TODO: 마지막 게시물 표시 변경
 const FooterLoading = styled.ActivityIndicator.attrs({
   size: 'small',
   color: colors.primary ?? '#888',

--- a/app/(page)/leenk.tsx
+++ b/app/(page)/leenk.tsx
@@ -69,7 +69,7 @@ export default function LeenkPage() {
     try {
       const status = tabToStatus(tab);
       const res = await getLeenkList(nextPage, PAGE_SIZE, status);
-      const pageItems = res.data.leenks ?? [];
+      const pageItems = res.leenks ?? [];
       const reachedEnd = pageItems.length < PAGE_SIZE;
 
       setData((prev) => (replace ? pageItems : [...prev, ...pageItems]));

--- a/app/(page)/leenk.tsx
+++ b/app/(page)/leenk.tsx
@@ -11,6 +11,8 @@ import { FEED_PADDING } from '@/constants';
 
 import { getLeenkList } from '@/api/leenk/leenk.get.api';
 import { Leenk } from '@/types/leenk';
+import { useUserStore } from '@/stores/userStore';
+import { useUserInfo } from '@/hooks/useUserInfo';
 
 const PAGE_SIZE = 10;
 const tabToStatus = (tab: 'all' | 'open' | 'close') =>
@@ -24,6 +26,15 @@ export default function LeenkPage() {
   const [loading, setLoading] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [hasMore, setHasMore] = useState(true);
+
+  const { userInfo: fetchedUserInfo } = useUserInfo();
+  const { userInfo, setUserInfo } = useUserStore();
+
+  useEffect(() => {
+    if (fetchedUserInfo && !userInfo) {
+      setUserInfo(fetchedUserInfo);
+    }
+  }, [fetchedUserInfo, userInfo, setUserInfo]);
 
   // 중복 호출 방지
   const onEndReachedCalledDuringMomentum = useRef(false);

--- a/app/(page)/leenk.tsx
+++ b/app/(page)/leenk.tsx
@@ -13,6 +13,7 @@ import { getLeenkList } from '@/api/leenk/leenk.get.api';
 import { Leenk } from '@/types/leenk';
 import { useUserStore } from '@/stores/userStore';
 import { useUserInfo } from '@/hooks/useUserInfo';
+import { useFocusEffect } from 'expo-router';
 
 const PAGE_SIZE = 10;
 const tabToStatus = (tab: 'all' | 'open' | 'close') =>
@@ -27,6 +28,8 @@ export default function LeenkPage() {
   const [refreshing, setRefreshing] = useState(false);
   const [hasMore, setHasMore] = useState(true);
 
+  const didMountRef = useRef(false);
+
   const { userInfo: fetchedUserInfo, refetch } = useUserInfo();
   const { userInfo, setUserInfo } = useUserStore();
 
@@ -39,6 +42,22 @@ export default function LeenkPage() {
       setUserInfo(fetchedUserInfo);
     }
   }, [fetchedUserInfo, userInfo, setUserInfo]);
+
+  // 페이지 변경 시 정보 업데이트
+  useFocusEffect(
+    React.useCallback(() => {
+      if (didMountRef.current) {
+        // 화면으로 복귀 시: 목록 리프레시
+        setHasMore(true);
+        setPage(0);
+        onEndReachedCalledDuringMomentum.current = false;
+        onRefresh(); // loadPage(0, true) 호출됨
+      } else {
+        // 첫 포커스(초기 진입)는 건너뛰기
+        didMountRef.current = true;
+      }
+    }, [tab]),
+  );
 
   // 중복 호출 방지
   const onEndReachedCalledDuringMomentum = useRef(false);
@@ -120,7 +139,7 @@ export default function LeenkPage() {
           loading ? (
             <FooterLoading />
           ) : !hasMore ? (
-            <FooterEnd>끝이에요</FooterEnd>
+            <FooterEnd></FooterEnd>
           ) : null
         }
       />

--- a/app/(page)/leenk.tsx
+++ b/app/(page)/leenk.tsx
@@ -15,7 +15,9 @@ import { useUserStore } from '@/stores/userStore';
 import { useUserInfo } from '@/hooks/useUserInfo';
 import { useFocusEffect } from 'expo-router';
 
-const PAGE_SIZE = 10;
+const FOOTER_SPACER = 10 * height;
+const PAGE_SIZE = 6;
+
 const tabToStatus = (tab: 'all' | 'open' | 'close') =>
   tab === 'all' ? 'ALL' : tab === 'open' ? 'OPEN' : 'CLOSED';
 
@@ -29,6 +31,8 @@ export default function LeenkPage() {
   const [hasMore, setHasMore] = useState(true);
 
   const didMountRef = useRef(false);
+
+  const listRef = useRef<import('react-native').FlatList<Leenk>>(null);
 
   const { userInfo: fetchedUserInfo, refetch } = useUserInfo();
   const { userInfo, setUserInfo } = useUserStore();
@@ -47,13 +51,12 @@ export default function LeenkPage() {
   useFocusEffect(
     React.useCallback(() => {
       if (didMountRef.current) {
-        // 화면으로 복귀 시: 목록 리프레시
+        // 화면으로 복귀, 목록 리프레시
         setHasMore(true);
         setPage(0);
         onEndReachedCalledDuringMomentum.current = false;
-        onRefresh(); // loadPage(0, true) 호출됨
+        onRefresh();
       } else {
-        // 첫 포커스(초기 진입)는 건너뛰기
         didMountRef.current = true;
       }
     }, [tab]),
@@ -62,7 +65,6 @@ export default function LeenkPage() {
   // 중복 호출 방지
   const onEndReachedCalledDuringMomentum = useRef(false);
 
-  // 첫 페이지 로드
   const loadPage = async (nextPage: number, replace = false) => {
     if (loading) return;
     setLoading(true);
@@ -80,25 +82,28 @@ export default function LeenkPage() {
     } finally {
       setLoading(false);
       setRefreshing(false);
+      onEndReachedCalledDuringMomentum.current = false;
     }
   };
 
-  // 초기화 및 탭 관리
+  // 초기화 및 탭 전환 시
   useEffect(() => {
     setData([]);
     setHasMore(true);
     setPage(0);
+    onEndReachedCalledDuringMomentum.current = false;
     loadPage(0, true);
   }, [tab]);
 
-  // 스크롤 당겨서 재호출
+  // 당겨서 새로고침
   const onRefresh = async () => {
     setRefreshing(true);
     setHasMore(true);
+    onEndReachedCalledDuringMomentum.current = false;
     await loadPage(0, true);
   };
 
-  // 무한스크롤
+  // 무한 스크롤 트리거
   const onEndReached = () => {
     if (onEndReachedCalledDuringMomentum.current) return;
     if (!loading && hasMore) {
@@ -123,19 +128,22 @@ export default function LeenkPage() {
       </View>
 
       <LeenkList
+        ref={listRef}
         data={data}
         keyExtractor={(item) => String(item.leenkId)}
         renderItem={({ item }) => <LeenkListItem item={item} />}
         ItemSeparatorComponent={() => <Separator />}
-        showsVerticalScrollIndicator
-        refreshing={refreshing}
-        onRefresh={onRefresh}
-        onEndReachedThreshold={0.6}
+        onEndReachedThreshold={0.3}
         onEndReached={onEndReached}
         onMomentumScrollBegin={() => {
           onEndReachedCalledDuringMomentum.current = false;
         }}
-        ListFooterComponent={loading ? <View /> : !hasMore ? <View /> : null}
+        refreshing={refreshing}
+        onRefresh={onRefresh}
+        showsVerticalScrollIndicator
+        ListFooterComponent={
+          <View style={{ height: FOOTER_SPACER, opacity: loading ? 0.6 : 0 }} />
+        }
       />
     </ContainerWithNoPadding>
   );

--- a/app/(page)/leenk.tsx
+++ b/app/(page)/leenk.tsx
@@ -36,7 +36,7 @@ export default function LeenkPage() {
     try {
       const status = tabToStatus(tab);
       const res = await getLeenkList(nextPage, PAGE_SIZE, status); // LeenkListResponse
-      const pageItems = res.leenks ?? [];
+      const pageItems = res.data.leenks ?? [];
       const reachedEnd = pageItems.length < PAGE_SIZE; // infer end by size
 
       setData((prev) => (replace ? pageItems : [...prev, ...pageItems]));
@@ -120,7 +120,6 @@ const List = styled.FlatList.attrs({
     paddingBottom: height * 20,
     paddingHorizontal: FEED_PADDING * width,
   },
-  // NOTE: keep default styles
 })`` as unknown as typeof import('react-native').FlatList<Leenk>;
 
 const Separator = styled.View`

--- a/app/(page)/mypage.tsx
+++ b/app/(page)/mypage.tsx
@@ -57,10 +57,10 @@ export default function MyPage() {
         text="피드 보기"
         onPress={() => router.push('/account/my-feed')}
       />
-      {/* <MyPageButton
+      <MyPageButton
         text="참여한 모임"
         onPress={() => router.push('/account/my-leenk')}
-      /> */}
+      />
     </Container>
   );
 }

--- a/app/(post)/leenk.tsx
+++ b/app/(post)/leenk.tsx
@@ -175,10 +175,7 @@ export default function PostLeenkPage() {
         await updateLeenk(leenkId, payload);
         showToast('수정 완료!', 'success');
         setCompleteModalOpen(false);
-        router.replace({
-          pathname: '/leenk/[id]',
-          params: { id: String(leenkId) },
-        });
+        router.back();
       } else {
         // 작성 API
         const res = await createLeenk(payload);
@@ -284,7 +281,7 @@ export default function PostLeenkPage() {
           size="lg"
           disabled={!isFormValid}
         >
-          {isEdit ? '수정하기' : '모집하자'}
+          {isEdit ? '수정할래' : '모집하자'}
         </CustomButton>
       </ScrollView>
 
@@ -304,10 +301,10 @@ export default function PostLeenkPage() {
         isOpen={completeModalOpen}
         onRightBtn={handleSubmit}
         onLeftBtn={() => setCompleteModalOpen(false)}
-        mainText={isEdit ? '이대로 수정할까?' : '모집하러 가볼까?'}
+        mainText={isEdit ? '수정할까?' : '모집하러 가볼까?'}
         isCancel={false}
         leftBtnText="취소"
-        rightBtnText={isEdit ? '수정하기' : '모집하기'}
+        rightBtnText={isEdit ? '수정할래' : '모집하기'}
         isLoading={submitting}
       />
     </KeyboardAwareScrollView>

--- a/app/(post)/leenk.tsx
+++ b/app/(post)/leenk.tsx
@@ -45,7 +45,6 @@ export default function PostLeenkPage() {
   const [submitting, setSubmitting] = useState(false);
   const { showToast } = useToastStore();
 
-  // ⬇️ 이미지 URL (Zustand)
   const { leenkImage, resetLeenkImage } = useLeenkImageStore();
 
   const handleBackPress = () => setIsBackModalOpen(true);
@@ -55,19 +54,15 @@ export default function PostLeenkPage() {
     router.push('/(page)/leenk');
   };
 
-  // is remote s3/http(s) url?
   const isRemoteUrl = (uri: string) => /^https?:\/\//i.test(uri);
-
-  // ensure pure object URL without query params
   const stripQuery = (url: string) => url.split('?')[0];
 
-  // ⬇️ 실제 제출 로직 (PATCH/POST)
   const handleSubmitCreate = async () => {
     if (!isFormValid || submitting) return;
     try {
       setSubmitting(true);
 
-      // 1) build ISO string like "YYYY-MM-DDTHH:mm:ss"
+      // 1) 시간 형식 ISO로 포멧팅
       const startTime = date
         ? [
             date.getFullYear(),
@@ -82,36 +77,35 @@ export default function PostLeenkPage() {
           ].join(':')
         : '';
 
-      // 2) resolve mediaUrl (upload if local)
+      // 2) s3 url 준비
       let finalMediaUrl = '';
       if (leenkImage) {
         if (isRemoteUrl(leenkImage)) {
-          // already remote; reuse
           finalMediaUrl = stripQuery(leenkImage);
         } else {
-          // local file -> get presigned, upload, then use object URL
+          // file S3에 등록
           const fileName = `leenk_${Date.now()}.jpg`;
           const presignedUrls = await getPresignedUrl(fileName);
           if (!presignedUrls || presignedUrls.length === 0) {
             throw new Error('Failed to get presigned URL.');
           }
-          const signed = presignedUrls[0].mediaUrl; // PUT url with query
-          await uploadImageToS3(signed, leenkImage /* local uri */);
-          finalMediaUrl = stripQuery(signed); // pure object url
+          const signed = presignedUrls[0].mediaUrl;
+          await uploadImageToS3(signed, leenkImage);
+          finalMediaUrl = stripQuery(signed);
         }
       }
 
-      // 3) build payload
+      // 3) payload 빌드
       const payload: UpdateLeenkPayload = {
         title: title.trim(),
         content: content.trim(),
         placeName: place.trim(),
         startTime,
         maxParticipants,
-        mediaUrl: finalMediaUrl, // <— use the S3 object URL (no query)
+        mediaUrl: finalMediaUrl,
       };
 
-      // 4) call API
+      // 4) API 호출
       const res = await createLeenk(payload);
 
       setCompleteModalOpen(false);
@@ -125,12 +119,10 @@ export default function PostLeenkPage() {
     }
   };
 
-  if (submitting) return <Loading />;
-
   const handleCompleteOpen = () => setCompleteModalOpen(true);
 
+  // 게시물 작성 시 이전에 선택한 이미지 삭제
   useEffect(() => {
-    // reset selected image when opening this page
     resetLeenkImage();
   }, [resetLeenkImage]);
 
@@ -242,6 +234,7 @@ export default function PostLeenkPage() {
         isCancel={false}
         leftBtnText="취소"
         rightBtnText="모집하기"
+        isLoading={submitting}
       />
     </KeyboardAvoidingView>
   );

--- a/app/(post)/leenk.tsx
+++ b/app/(post)/leenk.tsx
@@ -2,6 +2,7 @@ import {
   CustomButton,
   Header,
   Input,
+  Loading,
   PopupModal,
   Textarea,
 } from '@/components';
@@ -21,9 +22,15 @@ import {
 } from '@/theme/globalStyles';
 import { useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
-import { KeyboardAvoidingView, Platform } from 'react-native';
+import { KeyboardAvoidingView, Platform, Alert } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import styled from 'styled-components/native';
+
+import { createLeenk } from '@/api/leenk/leenk.post.api';
+import { UpdateLeenkPayload } from '@/types/leenk';
+import { uploadImageToS3 } from '@/api/file/s3Upload';
+import { getPresignedUrl } from '@/api/file/s3Upload';
+import { useToastStore } from '@/stores/toastStore';
 
 export default function PostLeenkPage() {
   const router = useRouter();
@@ -34,8 +41,13 @@ export default function PostLeenkPage() {
   const [place, setPlace] = useState('');
   const [date, setDate] = useState<Date | null>(null);
   const [content, setContent] = useState('');
+  const [maxParticipants, setMaxParticipants] = useState<number>(3);
+  const [submitting, setSubmitting] = useState(false);
+  const { showToast } = useToastStore();
 
-  const { resetLeenkImage } = useLeenkImageStore();
+  // ⬇️ 이미지 URL (Zustand)
+  const { leenkImage, resetLeenkImage } = useLeenkImageStore();
+
   const handleBackPress = () => setIsBackModalOpen(true);
 
   const handleConfirmExit = () => {
@@ -43,14 +55,84 @@ export default function PostLeenkPage() {
     router.push('/(page)/leenk');
   };
 
-  const handleComplete = () => {
-    setCompleteModalOpen(false);
-    router.push('/(page)/leenk');
+  // is remote s3/http(s) url?
+  const isRemoteUrl = (uri: string) => /^https?:\/\//i.test(uri);
+
+  // ensure pure object URL without query params
+  const stripQuery = (url: string) => url.split('?')[0];
+
+  // ⬇️ 실제 제출 로직 (PATCH/POST)
+  const handleSubmitCreate = async () => {
+    if (!isFormValid || submitting) return;
+    try {
+      setSubmitting(true);
+
+      // 1) build ISO string like "YYYY-MM-DDTHH:mm:ss"
+      const startTime = date
+        ? [
+            date.getFullYear(),
+            String(date.getMonth() + 1).padStart(2, '0'),
+            String(date.getDate()).padStart(2, '0'),
+          ].join('-') +
+          'T' +
+          [
+            String(date.getHours()).padStart(2, '0'),
+            String(date.getMinutes()).padStart(2, '0'),
+            '00',
+          ].join(':')
+        : '';
+
+      // 2) resolve mediaUrl (upload if local)
+      let finalMediaUrl = '';
+      if (leenkImage) {
+        if (isRemoteUrl(leenkImage)) {
+          // already remote; reuse
+          finalMediaUrl = stripQuery(leenkImage);
+        } else {
+          // local file -> get presigned, upload, then use object URL
+          const fileName = `leenk_${Date.now()}.jpg`;
+          const presignedUrls = await getPresignedUrl(fileName);
+          if (!presignedUrls || presignedUrls.length === 0) {
+            throw new Error('Failed to get presigned URL.');
+          }
+          const signed = presignedUrls[0].mediaUrl; // PUT url with query
+          await uploadImageToS3(signed, leenkImage /* local uri */);
+          finalMediaUrl = stripQuery(signed); // pure object url
+        }
+      }
+
+      // 3) build payload
+      const payload: UpdateLeenkPayload = {
+        title: title.trim(),
+        content: content.trim(),
+        placeName: place.trim(),
+        startTime,
+        maxParticipants,
+        mediaUrl: finalMediaUrl, // <— use the S3 object URL (no query)
+      };
+
+      // 4) call API
+      const res = await createLeenk(payload);
+
+      setCompleteModalOpen(false);
+      //TODO: 링크 상세 게시물 페이지로 바로 이동
+      router.push('/(page)/leenk');
+    } catch (e: any) {
+      if (__DEV__) console.log('createLeenk error:', e?.response ?? e);
+      showToast('등록에 실패했어. 잠시 후 다시 시도해 줘.', 'error');
+    } finally {
+      setSubmitting(false);
+    }
   };
 
+  if (submitting) return <Loading />;
+
+  const handleCompleteOpen = () => setCompleteModalOpen(true);
+
   useEffect(() => {
+    // reset selected image when opening this page
     resetLeenkImage();
-  }, []);
+  }, [resetLeenkImage]);
 
   const isFormValid =
     title.trim().length > 0 &&
@@ -77,6 +159,7 @@ export default function PostLeenkPage() {
           <SubText>원하는 사진을 선택하거나, 새로운 사진을 올려줘.</SubText>
         </Row>
         <LeenkImagePicker />
+
         <Margin />
         <Input
           title="제목"
@@ -86,6 +169,7 @@ export default function PostLeenkPage() {
           maxLength={30}
           isRequired
         />
+
         <Margin />
         <Input
           title="장소"
@@ -95,18 +179,22 @@ export default function PostLeenkPage() {
           maxLength={25}
           isRequired
         />
+
         <Margin />
         <Title>
           일시<Asterisk> *</Asterisk>
         </Title>
 
         <CalendarButton value={date} onChange={setDate} />
+
         <Margin />
         <Row>
           <Title>모임 인원</Title>
           <SubText>나 포함 최소 3명부터 모임을 만들 수 있어.</SubText>
         </Row>
-        <Stepper />
+
+        <Stepper value={maxParticipants} onChange={setMaxParticipants} />
+
         <Margin />
         <Textarea
           title="내용"
@@ -119,11 +207,11 @@ export default function PostLeenkPage() {
           fontSizeKey="lg"
           isRequired
         />
-        <Margin />
 
+        <Margin />
         <CustomButton
           variant="primary"
-          onPress={() => setCompleteModalOpen(true)}
+          onPress={handleCompleteOpen}
           fullWidth
           rounded="md"
           size="lg"
@@ -133,6 +221,7 @@ export default function PostLeenkPage() {
         </CustomButton>
       </ScrollView>
 
+      {/* 뒤로가기 확인 */}
       <PopupModal
         isOpen={isBackModalOpen}
         onRightBtn={handleConfirmExit}
@@ -143,9 +232,11 @@ export default function PostLeenkPage() {
         leftBtnText="취소"
         rightBtnText="그만두기"
       />
+
+      {/* 최종 제출 확인 → 실제 API 호출 */}
       <PopupModal
         isOpen={completeModalOpen}
-        onRightBtn={handleComplete}
+        onRightBtn={handleSubmitCreate}
         onLeftBtn={() => setCompleteModalOpen(false)}
         mainText="모집하러 가볼까?"
         isCancel={false}

--- a/app/(post)/leenk.tsx
+++ b/app/(post)/leenk.tsx
@@ -24,6 +24,7 @@ import { useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
 import { KeyboardAvoidingView, Platform, Alert } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import styled from 'styled-components/native';
 
 import { createLeenk } from '@/api/leenk/leenk.post.api';
@@ -133,9 +134,15 @@ export default function PostLeenkPage() {
     date !== null;
 
   return (
-    <KeyboardAvoidingView
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      style={{ flex: 1 }}
+    <KeyboardAwareScrollView
+      style={{ flex: 1, backgroundColor: colors.bg[2] }}
+      contentContainerStyle={{
+        paddingBottom: 60 * height,
+        flexGrow: 1,
+      }}
+      enableOnAndroid={true}
+      extraScrollHeight={180 * height}
+      keyboardShouldPersistTaps="handled"
     >
       <ScrollView
         style={{ flex: 1, backgroundColor: colors.bg[2] }}
@@ -236,7 +243,7 @@ export default function PostLeenkPage() {
         rightBtnText="모집하기"
         isLoading={submitting}
       />
-    </KeyboardAvoidingView>
+    </KeyboardAwareScrollView>
   );
 }
 

--- a/app/(post)/leenk.tsx
+++ b/app/(post)/leenk.tsx
@@ -20,21 +20,29 @@ import {
   lineHeight,
   width,
 } from '@/theme/globalStyles';
-import { useRouter } from 'expo-router';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
-import { KeyboardAvoidingView, Platform, Alert } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import styled from 'styled-components/native';
 
 import { createLeenk } from '@/api/leenk/leenk.post.api';
-import { UpdateLeenkPayload } from '@/types/leenk';
+import { LeenkDetail, UpdateLeenkPayload } from '@/types/leenk';
 import { uploadImageToS3 } from '@/api/file/s3Upload';
 import { getPresignedUrl } from '@/api/file/s3Upload';
 import { useToastStore } from '@/stores/toastStore';
+import { updateLeenk } from '@/api/leenk/leenk.patch.api';
+import { getLeenkDetail } from '@/api/leenk/leenk.get.api';
 
 export default function PostLeenkPage() {
   const router = useRouter();
+  const { mode, leenkId: leenkIdParam } = useLocalSearchParams<{
+    mode?: string;
+    leenkId?: string;
+  }>();
+
+  const isEdit = mode === 'edit';
+  const leenkId = Number(leenkIdParam);
 
   const [isBackModalOpen, setIsBackModalOpen] = useState(false);
   const [completeModalOpen, setCompleteModalOpen] = useState(false);
@@ -44,9 +52,76 @@ export default function PostLeenkPage() {
   const [content, setContent] = useState('');
   const [maxParticipants, setMaxParticipants] = useState<number>(3);
   const [submitting, setSubmitting] = useState(false);
+  const [hydrating, setHydrating] = useState(isEdit);
   const { showToast } = useToastStore();
 
-  const { leenkImage, resetLeenkImage } = useLeenkImageStore();
+  const { leenkImage, resetLeenkImage, setLeenkImage } = useLeenkImageStore();
+  // setLeenkImage가 없다면 leenkStore에 아래 setter 하나만 추가:
+  // setLeenkImage: (uri: string | null) => set({ leenkImage: uri })
+
+  // ISO 문자열로 변환
+  const toISODateTime = (d: Date) =>
+    [
+      d.getFullYear(),
+      String(d.getMonth() + 1).padStart(2, '0'),
+      String(d.getDate()).padStart(2, '0'),
+    ].join('-') +
+    'T' +
+    [
+      String(d.getHours()).padStart(2, '0'),
+      String(d.getMinutes()).padStart(2, '0'),
+      '00',
+    ].join(':');
+
+  const isRemoteUrl = (uri: string) => /^https?:\/\//i.test(uri);
+  const stripQuery = (url: string) => url.split('?')[0];
+
+  // 수정 모드일 때 기존 데이터로 폼 채우기
+  useEffect(() => {
+    // 새 글쓰기일 때만 이전 선택 이미지 초기화
+    if (!isEdit) resetLeenkImage();
+  }, [isEdit, resetLeenkImage]);
+
+  useEffect(() => {
+    if (!isEdit || !Number.isFinite(leenkId)) return;
+
+    let mounted = true;
+    (async () => {
+      try {
+        setHydrating(true);
+        const detail: LeenkDetail = await getLeenkDetail(leenkId);
+        if (!mounted) return;
+
+        setTitle(detail.title ?? '');
+        setPlace(detail.placeName ?? '');
+        setContent(detail.content ?? '');
+        setMaxParticipants(detail.maxParticipants ?? 3);
+
+        // startTime(예: '2025-08-17T12:30:00')을 Date로 변환
+        if (detail.startTime) {
+          const d = new Date(detail.startTime);
+          if (!isNaN(d.getTime())) setDate(d);
+        }
+
+        // 이미지 셋
+        if (detail.mediaUrl) {
+          // 편집 시 기존 이미지 유지
+          setLeenkImage(stripQuery(detail.mediaUrl));
+        } else {
+          setLeenkImage(null);
+        }
+      } catch (e) {
+        showToast('수정 정보를 불러오지 못했어.', 'error');
+        router.back();
+      } finally {
+        setHydrating(false);
+      }
+    })();
+
+    return () => {
+      mounted = false;
+    };
+  }, [isEdit, leenkId]);
 
   const handleBackPress = () => setIsBackModalOpen(true);
 
@@ -55,48 +130,37 @@ export default function PostLeenkPage() {
     router.push('/(page)/leenk');
   };
 
-  const isRemoteUrl = (uri: string) => /^https?:\/\//i.test(uri);
-  const stripQuery = (url: string) => url.split('?')[0];
+  const isFormValid =
+    title.trim().length > 0 &&
+    place.trim().length > 0 &&
+    content.trim().length > 0 &&
+    date !== null;
 
-  const handleSubmitCreate = async () => {
+  // 공통: S3 업로드 or 기존 URL 재사용
+  const prepareMediaUrl = async (): Promise<string> => {
+    if (!leenkImage) return '';
+    if (isRemoteUrl(leenkImage)) return stripQuery(leenkImage);
+
+    const fileName = `leenk_${Date.now()}.jpg`;
+    const presignedUrls = await getPresignedUrl(fileName);
+    if (!presignedUrls || presignedUrls.length === 0) {
+      throw new Error('Failed to get presigned URL.');
+    }
+    const signed = presignedUrls[0].mediaUrl;
+    await uploadImageToS3(signed, leenkImage);
+    return stripQuery(signed);
+  };
+
+  // 작성 / 수정 분기
+  const handleSubmit = async () => {
     if (!isFormValid || submitting) return;
+
     try {
       setSubmitting(true);
 
-      // 1) 시간 형식 ISO로 포멧팅
-      const startTime = date
-        ? [
-            date.getFullYear(),
-            String(date.getMonth() + 1).padStart(2, '0'),
-            String(date.getDate()).padStart(2, '0'),
-          ].join('-') +
-          'T' +
-          [
-            String(date.getHours()).padStart(2, '0'),
-            String(date.getMinutes()).padStart(2, '0'),
-            '00',
-          ].join(':')
-        : '';
+      const startTime = date ? toISODateTime(date) : '';
+      const finalMediaUrl = await prepareMediaUrl();
 
-      // 2) s3 url 준비
-      let finalMediaUrl = '';
-      if (leenkImage) {
-        if (isRemoteUrl(leenkImage)) {
-          finalMediaUrl = stripQuery(leenkImage);
-        } else {
-          // file S3에 등록
-          const fileName = `leenk_${Date.now()}.jpg`;
-          const presignedUrls = await getPresignedUrl(fileName);
-          if (!presignedUrls || presignedUrls.length === 0) {
-            throw new Error('Failed to get presigned URL.');
-          }
-          const signed = presignedUrls[0].mediaUrl;
-          await uploadImageToS3(signed, leenkImage);
-          finalMediaUrl = stripQuery(signed);
-        }
-      }
-
-      // 3) payload 빌드
       const payload: UpdateLeenkPayload = {
         title: title.trim(),
         content: content.trim(),
@@ -106,15 +170,26 @@ export default function PostLeenkPage() {
         mediaUrl: finalMediaUrl,
       };
 
-      // 4) API 호출
-      const res = await createLeenk(payload);
-
-      setCompleteModalOpen(false);
-      //TODO: 링크 상세 게시물 페이지로 바로 이동
-      router.push('/(page)/leenk');
+      if (isEdit) {
+        // 수정 API
+        await updateLeenk(leenkId, payload);
+        showToast('수정 완료!', 'success');
+        setCompleteModalOpen(false);
+        router.replace({
+          pathname: '/leenk/[id]',
+          params: { id: String(leenkId) },
+        });
+      } else {
+        // 작성 API
+        const res = await createLeenk(payload);
+        console.log('링크 등록 응답: ', res);
+        showToast('등록 완료!', 'success');
+        setCompleteModalOpen(false);
+        router.push('/(page)/leenk');
+      }
     } catch (e: any) {
-      if (__DEV__) console.log('createLeenk error:', e?.response ?? e);
-      showToast('등록에 실패했어. 잠시 후 다시 시도해 줘.', 'error');
+      if (__DEV__) console.log('submit error:', e?.response ?? e);
+      showToast(isEdit ? '수정에 실패했어.' : '등록에 실패했어.', 'error');
     } finally {
       setSubmitting(false);
     }
@@ -122,16 +197,9 @@ export default function PostLeenkPage() {
 
   const handleCompleteOpen = () => setCompleteModalOpen(true);
 
-  // 게시물 작성 시 이전에 선택한 이미지 삭제
-  useEffect(() => {
-    resetLeenkImage();
-  }, [resetLeenkImage]);
-
-  const isFormValid =
-    title.trim().length > 0 &&
-    place.trim().length > 0 &&
-    content.trim().length > 0 &&
-    date !== null;
+  if (hydrating) {
+    return <Loading />;
+  }
 
   return (
     <KeyboardAwareScrollView
@@ -216,7 +284,7 @@ export default function PostLeenkPage() {
           size="lg"
           disabled={!isFormValid}
         >
-          모집하자
+          {isEdit ? '수정하기' : '모집하자'}
         </CustomButton>
       </ScrollView>
 
@@ -225,22 +293,21 @@ export default function PostLeenkPage() {
         isOpen={isBackModalOpen}
         onRightBtn={handleConfirmExit}
         onLeftBtn={() => setIsBackModalOpen(false)}
-        mainText="글 작성을 그만둘래?"
+        mainText={isEdit ? '수정을 그만둘래?' : '글 작성을 그만둘래?'}
         subText="작성하던 내용은 저장되지 않아."
-        isCancel={true}
+        isCancel
         leftBtnText="취소"
         rightBtnText="그만두기"
       />
-
-      {/* 최종 제출 확인 → 실제 API 호출 */}
+      {/* 최종 제출 확인 */}
       <PopupModal
         isOpen={completeModalOpen}
-        onRightBtn={handleSubmitCreate}
+        onRightBtn={handleSubmit}
         onLeftBtn={() => setCompleteModalOpen(false)}
-        mainText="모집하러 가볼까?"
+        mainText={isEdit ? '이대로 수정할까?' : '모집하러 가볼까?'}
         isCancel={false}
         leftBtnText="취소"
-        rightBtnText="모집하기"
+        rightBtnText={isEdit ? '수정하기' : '모집하기'}
         isLoading={submitting}
       />
     </KeyboardAwareScrollView>

--- a/app/(post)/leenk/[id]/index.tsx
+++ b/app/(post)/leenk/[id]/index.tsx
@@ -85,7 +85,10 @@ export default function LeenkDetailPage() {
     openModal('deleteConfirm');
   };
 
-  const handleEdit = () => closeModal();
+  const handleEdit = () => {
+    //TODO:수정하기 로직 추가
+    closeModal();
+  };
 
   const handleReport = () => {
     closeModal();
@@ -99,7 +102,16 @@ export default function LeenkDetailPage() {
   };
 
   const handleParticipants = () => {
-    router.push('/leenk/participants-list');
+    if (!leenkDetail) return;
+
+    router.push({
+      pathname: '/leenk/participants-list',
+      params: {
+        leenkId: String(leenkDetail.id),
+        isAuthor: String(isAuthor),
+        maxParticipants: String(leenkDetail.maxParticipants),
+      },
+    });
   };
 
   const handleConfirmDelete = async () => {

--- a/app/(post)/leenk/[id]/index.tsx
+++ b/app/(post)/leenk/[id]/index.tsx
@@ -15,7 +15,7 @@ import { height, width } from '@/theme/globalStyles';
 import { useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router';
 import styled from 'styled-components/native';
 
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Share } from 'react-native';
@@ -28,9 +28,14 @@ import { getLeenkDetail } from '@/api/leenk/leenk.get.api';
 import { LeenkDetail } from '@/types/leenk';
 import { useUserStore } from '@/stores/userStore';
 import { deleteLeenk, leaveLeenk } from '@/api/leenk/leenk.del.api';
-import { participantLeenk } from '@/api/leenk/leenk.post.api';
+import {
+  closeLeenk,
+  finishLeenk,
+  participantLeenk,
+} from '@/api/leenk/leenk.post.api';
 import LeenkDetailModals from '@/components/leenk/LeenkDetailModals';
-
+import * as Linking from 'expo-linking';
+import * as Clipboard from 'expo-clipboard';
 export default function LeenkDetailPage() {
   const { id } = useLocalSearchParams<{ id: string | string[] }>();
   const leenkId = useMemo(() => Number(Array.isArray(id) ? id[0] : id), [id]);
@@ -47,6 +52,7 @@ export default function LeenkDetailPage() {
   const [joining, setJoining] = useState(false);
   const [leaving, setLeaving] = useState(false);
   const [isParticipating, setIsParticipating] = useState(false);
+  const [leenkStatus, setLeenkStatus] = useState('');
   const [isLeenkEnd, setIsLeenkEnd] = useState(false);
 
   const isAuthor = useMemo(
@@ -54,7 +60,6 @@ export default function LeenkDetailPage() {
     [leenkDetail, userInfo?.id],
   );
 
-  // console.log(isAuthor, leenkDetail?.author.userId, userInfo?.id);
   const isBusy = loading || deleting || joining || leaving;
 
   const fetchDetail = useCallback(async () => {
@@ -68,7 +73,11 @@ export default function LeenkDetailPage() {
     setLoading(true);
     try {
       const data = await getLeenkDetail(leenkId);
-      if (active) setLeenkDetail(data);
+      if (active) {
+        setLeenkDetail(data);
+        setLeenkStatus(data.status);
+        console.log('링크의 상태:', data.status);
+      }
     } catch (e) {
       if (active) {
         showToast('상세 정보를 불러오지 못했어.', 'error');
@@ -94,33 +103,38 @@ export default function LeenkDetailPage() {
     }, [fetchDetail]),
   );
 
-  const handleDelete = useCallback(() => {
-    closeModal();
-    openModal('deleteConfirm');
-  }, [closeModal, openModal]);
-
-  const handleEdit = useCallback(() => {
-    closeModal();
-    router.push({
-      pathname: '/(post)/leenk',
-      params: { mode: 'edit', leenkId: String(leenkDetail?.id ?? '') },
-    });
-  }, [closeModal, router, leenkDetail?.id]);
-
+  // 링크 신고 함수
   const handleReport = useCallback(() => {
     closeModal();
     openModal('leenkReport');
   }, [closeModal, openModal]);
 
-  const handleLeenkCloseModal = useCallback(
-    () => openModal('leenkClose'),
-    [openModal],
-  );
-  const handleLeenkClose = useCallback(
-    () => openModal('bottomSheet'),
-    [openModal],
-  );
+  // 링크 모집 종료 함수
+  const handleLeenkClose = async (leenkId: number) => {
+    try {
+      await closeLeenk(leenkId);
+      closeModal();
+      showToast('링크 모집을 종료했어요.');
+    } catch (err) {
+      console.error('링크 모집 종료 실패:', err);
+      showToast('링크 모집 종료에 실패했어요.');
+    }
+  };
+  // 링크 모임 종료 함수
+  const handleLeenkFinish = async (leenkId: number) => {
+    try {
+      await finishLeenk(leenkId);
+      closeModal();
+      showToast('링크 모임을 종료했어요.');
+      // 종료 후 바텀시트 띄우기
+      openModal('bottomSheet');
+    } catch (err) {
+      console.error('링크 모임 종료 실패:', err);
+      showToast('링크 모임 종료에 실패했어요.');
+    }
+  };
 
+  // 참여자 페이지 이동
   const handleParticipants = useCallback(() => {
     if (!leenkDetail) return;
     router.push({
@@ -133,6 +147,7 @@ export default function LeenkDetailPage() {
     });
   }, [leenkDetail, isAuthor, router]);
 
+  // 링크 삭제하기 버튼(작성자)
   const handleConfirmDelete = useCallback(async () => {
     if (!leenkDetail || deleting) return;
     try {
@@ -149,6 +164,22 @@ export default function LeenkDetailPage() {
     }
   }, [leenkDetail, deleting, closeModal, router, showToast]);
 
+  // 삭제하기 모달(작성자)
+  const handleDelete = useCallback(() => {
+    closeModal();
+    openModal('deleteConfirm');
+  }, [closeModal, openModal]);
+
+  // 수정하기 페이지 이동(작성자)
+  const handleEdit = useCallback(() => {
+    closeModal();
+    router.push({
+      pathname: '/(post)/leenk',
+      params: { mode: 'edit', leenkId: String(leenkDetail?.id ?? '') },
+    });
+  }, [closeModal, router, leenkDetail?.id]);
+
+  // 링크 떠나기(참여자)
   const handleLeave = useCallback(async () => {
     if (!leenkDetail || leaving || !isParticipating) {
       closeModal();
@@ -177,6 +208,7 @@ export default function LeenkDetailPage() {
     }
   }, [leenkDetail, leaving, isParticipating, closeModal, showToast]);
 
+  // 링크 참여하기(참여자)
   const handleJoinLeenk = useCallback(async () => {
     if (!leenkDetail || joining || isParticipating) return;
     try {
@@ -198,15 +230,36 @@ export default function LeenkDetailPage() {
     }
   }, [leenkDetail, joining, isParticipating, showToast]);
 
-  const handleShare = useCallback(async () => {
+  // 공유하기(작성자,침여자)
+  const handleShare = async () => {
     try {
-      if (leenkDetail?.title) {
-        await Share.share({ message: leenkDetail.title });
+      if (!leenkId) {
+        showToast('공유할 링크를 만들 수 없어요.', 'error');
+        return;
+      }
+
+      // 커스텀 스킴 딥링크 생성 (app.json의 scheme와 동일해야 함: 예 "leenk")
+      //    path는 expo-router 라우트와 일치: /leenk/[id]
+      const deepLink = Linking.createURL(`/leenk/${leenkId}`, {
+        scheme: 'leenk',
+      });
+      // 예: "leenk://leenk/123"
+
+      // iOS는 url 필드를 더 잘 인식
+      if (Platform.OS === 'ios') {
+        await Share.share({ url: deepLink, message: leenkDetail?.title });
+      } else {
+        await Share.share({ message: `${leenkDetail?.title}\n${deepLink}` });
       }
     } catch {
-      showToast('공유에 실패했어', 'error');
+      // 실패 시 클립보드 복사 폴백
+      const fallback = Linking.createURL(`/leenk/${leenkId}`, {
+        scheme: 'leenk',
+      });
+      await Clipboard.setStringAsync(fallback);
+      showToast('링크를 클립보드에 복사했어요', 'success');
     }
-  }, [leenkDetail?.title, showToast]);
+  };
 
   if (isBusy || !leenkDetail) {
     return <Loading />;
@@ -249,11 +302,11 @@ export default function LeenkDetailPage() {
         isParticipating={isParticipating}
         insetBottom={insets.bottom}
         onLeave={() => openModal('leenkLeave')}
-        onEalryClose={() => openModal('leenkEarlyClose')}
-        onClose={handleLeenkCloseModal}
+        onFinish={() => openModal('leenkFinish')}
+        onClose={() => openModal('leenkClose')}
         onJoin={handleJoinLeenk}
         onParticipants={handleParticipants}
-        isLeenkEnd={isLeenkEnd}
+        leenkStatus={leenkStatus}
       />
 
       <MenuModal
@@ -273,7 +326,8 @@ export default function LeenkDetailPage() {
         onClose={closeModal}
         onConfirmDelete={handleConfirmDelete}
         onConfirmLeave={handleLeave}
-        onConfirmClose={handleLeenkClose}
+        onConfirmClose={() => handleLeenkClose(leenkDetail.id)}
+        onConfirmFinish={() => handleLeenkFinish(leenkDetail.id)}
       />
 
       {modalType === 'bottomSheet' && (

--- a/app/(post)/leenk/[id]/index.tsx
+++ b/app/(post)/leenk/[id]/index.tsx
@@ -29,7 +29,8 @@ import ReportModal from '@/components/Modal/ReportModal';
 import { getLeenkDetail } from '@/api/leenk/leenk.get.api';
 import { LeenkDetail } from '@/types/leenk';
 import { useUserStore } from '@/stores/userStore';
-import { deleteLeenk } from '@/api/leenk/leenk.del.api';
+import { deleteLeenk, leaveLeenk } from '@/api/leenk/leenk.del.api';
+import { participantLeenk } from '@/api/leenk/leenk.post.api';
 
 export default function LeenkDetailPage() {
   const { id } = useLocalSearchParams<{ id: string | string[] }>();
@@ -46,6 +47,8 @@ export default function LeenkDetailPage() {
   const [leenkDetail, setLeenkDetail] = useState<LeenkDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [deleting, setDeleting] = useState(false);
+  const [joining, setJoining] = useState(false);
+  const [leaving, setLeaving] = useState(false);
 
   const { userInfo } = useUserStore();
 
@@ -73,7 +76,7 @@ export default function LeenkDetailPage() {
 
   const isAuthor = leenkDetail?.author.userId === userInfo?.id;
 
-  if (loading || !leenkDetail || deleting) {
+  if (loading || !leenkDetail || deleting || joining || leaving) {
     return <Loading />;
   }
 
@@ -112,21 +115,57 @@ export default function LeenkDetailPage() {
       router.replace('/feed');
     } catch (err: any) {
       console.error('링크 삭제 오류:', err);
-      showToast('삭제에 실패했어요. 잠시 후 다시 시도해 주세요.', 'error');
+      showToast('삭제에 실패했어. 잠시 후 다시 시도해 줘.', 'error');
     } finally {
       setDeleting(false);
     }
   };
 
-  const handleLeave = () => {
-    setIsParticipating(false);
-    closeModal();
-    // TODO: 유저 나가기 api 추가
+  const handleLeave = async () => {
+    if (!leenkDetail || leaving || !isParticipating) {
+      closeModal();
+      return;
+    }
+    try {
+      setLeaving(true);
+      await leaveLeenk(leenkDetail.id);
+
+      setIsParticipating(false);
+      setLeenkDetail((prev) =>
+        prev
+          ? {
+              ...prev,
+              currentParticipants: Math.max(prev.currentParticipants - 1, 0),
+            }
+          : prev,
+      );
+      showToast('모임에서 나갔어.', 'success');
+    } catch (e) {
+      showToast('나가기에 실패했어. 잠시 후 다시 시도해 줘.', 'error');
+    } finally {
+      setLeaving(false);
+      closeModal();
+    }
   };
 
-  const handleJoinLeenk = () => {
-    // TODO: 링크 참여하기 api 연결
-    setIsParticipating(true);
+  const handleJoinLeenk = async () => {
+    if (!leenkDetail || joining || isParticipating) return;
+    try {
+      setJoining(true);
+      await participantLeenk(leenkDetail.id);
+
+      setIsParticipating(true);
+      setLeenkDetail((prev) =>
+        prev
+          ? { ...prev, currentParticipants: prev.currentParticipants + 1 }
+          : prev,
+      );
+      showToast('참여했어!', 'success');
+    } catch (e) {
+      showToast('참여에 실패했어. 잠시 후 다시 시도해 줘.', 'error');
+    } finally {
+      setJoining(false);
+    }
   };
 
   const handleShare = async () => {

--- a/app/(post)/leenk/[id]/index.tsx
+++ b/app/(post)/leenk/[id]/index.tsx
@@ -215,6 +215,7 @@ export default function LeenkDetailPage() {
     applyParticipatePatch(-1, false);
     try {
       await leaveLeenk(leenkDetail.id);
+      showToast('링크를 떠났어!');
       closeModal();
       await refetchDetail();
     } catch {
@@ -229,6 +230,7 @@ export default function LeenkDetailPage() {
     applyParticipatePatch(+1, true);
     try {
       await participantLeenk(leenkDetail.id);
+      showToast('링크에 참여했어!');
       closeModal();
       await refetchDetail();
     } catch {

--- a/app/(post)/leenk/[id]/index.tsx
+++ b/app/(post)/leenk/[id]/index.tsx
@@ -5,7 +5,6 @@ import {
   Header,
   Loading,
   MenuModal,
-  PopupModal,
 } from '@/components';
 import GradientOverlay from '@/components/feed/GradientOverlay';
 import { CONTAINER_PADDING } from '@/constants';
@@ -13,7 +12,7 @@ import { useModalStore } from '@/stores/modalStore';
 import { useToastStore } from '@/stores/toastStore';
 import colors from '@/theme/color';
 import { height, width } from '@/theme/globalStyles';
-import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router';
 import styled from 'styled-components/native';
 
 import { StyleSheet } from 'react-native';
@@ -21,16 +20,16 @@ import { Image } from 'expo-image';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Share } from 'react-native';
 import { SubText, TitleText } from '@/components/OnBoarding';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import LeenkContentSection from '@/components/leenk/LeenkDetailContent';
 import LeenkBottomButtonSection from '@/components/leenk/LeenkDetailBottomButton';
-import ReportModal from '@/components/Modal/ReportModal';
 
 import { getLeenkDetail } from '@/api/leenk/leenk.get.api';
 import { LeenkDetail } from '@/types/leenk';
 import { useUserStore } from '@/stores/userStore';
 import { deleteLeenk, leaveLeenk } from '@/api/leenk/leenk.del.api';
 import { participantLeenk } from '@/api/leenk/leenk.post.api';
+import LeenkDetailModals from '@/components/leenk/LeenkDetailModals';
 
 export default function LeenkDetailPage() {
   const { id } = useLocalSearchParams<{ id: string | string[] }>();
@@ -40,73 +39,88 @@ export default function LeenkDetailPage() {
   const { showToast } = useToastStore();
   const router = useRouter();
   const insets = useSafeAreaInsets();
-
-  const [isParticipating, setIsParticipating] = useState(false);
-  const [isLeenkEnd, setIsLeenkEnd] = useState(false);
+  const { userInfo } = useUserStore();
 
   const [leenkDetail, setLeenkDetail] = useState<LeenkDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [deleting, setDeleting] = useState(false);
   const [joining, setJoining] = useState(false);
   const [leaving, setLeaving] = useState(false);
+  const [isParticipating, setIsParticipating] = useState(false);
+  const [isLeenkEnd, setIsLeenkEnd] = useState(false);
 
-  const { userInfo } = useUserStore();
+  const isAuthor = useMemo(
+    () => (leenkDetail ? leenkDetail.author.userId === userInfo?.id : false),
+    [leenkDetail, userInfo?.id],
+  );
+  const isBusy = loading || deleting || joining || leaving;
 
-  useEffect(() => {
-    let mounted = true;
-    (async () => {
-      try {
-        setLoading(true);
-        if (!Number.isFinite(leenkId)) {
-          throw new Error('Invalid leenk id');
-        }
-        const data = await getLeenkDetail(leenkId);
-        if (mounted) setLeenkDetail(data);
-      } catch (e) {
+  const fetchDetail = useCallback(async () => {
+    if (!Number.isFinite(leenkId)) {
+      showToast('잘못된 링크야.', 'error');
+      router.back();
+      return;
+    }
+
+    let active = true;
+    setLoading(true);
+    try {
+      const data = await getLeenkDetail(leenkId);
+      if (active) setLeenkDetail(data);
+    } catch (e) {
+      if (active) {
         showToast('상세 정보를 불러오지 못했어.', 'error');
         router.back();
-      } finally {
-        if (mounted) setLoading(false);
       }
-    })();
+    } finally {
+      if (active) setLoading(false);
+    }
     return () => {
-      mounted = false;
+      active = false;
     };
-  }, [leenkId]);
+  }, [leenkId, router, showToast]);
 
-  const isAuthor = leenkDetail?.author.userId === userInfo?.id;
+  useFocusEffect(
+    useCallback(() => {
+      let cleanup: (() => void) | undefined;
+      (async () => {
+        cleanup = await fetchDetail();
+      })();
+      return () => {
+        cleanup?.();
+      };
+    }, [fetchDetail]),
+  );
 
-  if (loading || !leenkDetail || deleting || joining || leaving) {
-    return <Loading />;
-  }
-
-  const handleDelete = () => {
+  const handleDelete = useCallback(() => {
     closeModal();
     openModal('deleteConfirm');
-  };
+  }, [closeModal, openModal]);
 
-  const handleEdit = () => {
+  const handleEdit = useCallback(() => {
     closeModal();
     router.push({
       pathname: '/(post)/leenk',
       params: { mode: 'edit', leenkId: String(leenkDetail?.id ?? '') },
     });
-  };
+  }, [closeModal, router, leenkDetail?.id]);
 
-  const handleReport = () => {
+  const handleReport = useCallback(() => {
     closeModal();
     openModal('leenkReport');
-  };
+  }, [closeModal, openModal]);
 
-  const handleLeenkCloseModal = () => openModal('leenkClose');
+  const handleLeenkCloseModal = useCallback(
+    () => openModal('leenkClose'),
+    [openModal],
+  );
+  const handleLeenkClose = useCallback(
+    () => openModal('bottomSheet'),
+    [openModal],
+  );
 
-  const handleLeenkClose = () => {
-    openModal('bottomSheet');
-  };
-
-  const handleParticipants = () => {
+  const handleParticipants = useCallback(() => {
     if (!leenkDetail) return;
-
     router.push({
       pathname: '/leenk/participants-list',
       params: {
@@ -115,28 +129,25 @@ export default function LeenkDetailPage() {
         maxParticipants: String(leenkDetail.maxParticipants),
       },
     });
-  };
+  }, [leenkDetail, isAuthor, router]);
 
-  const handleConfirmDelete = async () => {
+  const handleConfirmDelete = useCallback(async () => {
+    if (!leenkDetail || deleting) return;
     try {
-      if (!leenkDetail) return;
       setDeleting(true);
-
       await deleteLeenk(leenkDetail.id);
-
       showToast('삭제 완료!', 'success');
       closeModal();
-
       router.replace('/feed');
-    } catch (err: any) {
+    } catch (err) {
       console.error('링크 삭제 오류:', err);
       showToast('삭제에 실패했어. 잠시 후 다시 시도해 줘.', 'error');
     } finally {
       setDeleting(false);
     }
-  };
+  }, [leenkDetail, deleting, closeModal, router, showToast]);
 
-  const handleLeave = async () => {
+  const handleLeave = useCallback(async () => {
     if (!leenkDetail || leaving || !isParticipating) {
       closeModal();
       return;
@@ -145,6 +156,7 @@ export default function LeenkDetailPage() {
       setLeaving(true);
       await leaveLeenk(leenkDetail.id);
 
+      // Optimistic local update
       setIsParticipating(false);
       setLeenkDetail((prev) =>
         prev
@@ -155,20 +167,21 @@ export default function LeenkDetailPage() {
           : prev,
       );
       showToast('모임에서 나갔어.', 'success');
-    } catch (e) {
+    } catch {
       showToast('나가기에 실패했어. 잠시 후 다시 시도해 줘.', 'error');
     } finally {
       setLeaving(false);
       closeModal();
     }
-  };
+  }, [leenkDetail, leaving, isParticipating, closeModal, showToast]);
 
-  const handleJoinLeenk = async () => {
+  const handleJoinLeenk = useCallback(async () => {
     if (!leenkDetail || joining || isParticipating) return;
     try {
       setJoining(true);
       await participantLeenk(leenkDetail.id);
 
+      // Optimistic local update
       setIsParticipating(true);
       setLeenkDetail((prev) =>
         prev
@@ -176,101 +189,36 @@ export default function LeenkDetailPage() {
           : prev,
       );
       showToast('참여했어!', 'success');
-    } catch (e) {
+    } catch {
       showToast('참여에 실패했어. 잠시 후 다시 시도해 줘.', 'error');
     } finally {
       setJoining(false);
     }
-  };
+  }, [leenkDetail, joining, isParticipating, showToast]);
 
-  const handleShare = async () => {
+  const handleShare = useCallback(async () => {
     try {
-      await Share.share({ message: leenkDetail.title });
-    } catch (error) {
+      if (leenkDetail?.title) {
+        await Share.share({ message: leenkDetail.title });
+      }
+    } catch {
       showToast('공유에 실패했어요', 'error');
     }
-  };
+  }, [leenkDetail?.title, showToast]);
 
-  const renderPopupModal = () => {
-    switch (modalType) {
-      case 'deleteConfirm':
-        return (
-          <PopupModal
-            isOpen
-            onRightBtn={handleConfirmDelete}
-            onLeftBtn={closeModal}
-            isWarning
-            mainText="모집글을 삭제할거야?"
-            subText="삭제하면 복구할 수 없어."
-            isCancel
-            leftBtnText="취소"
-            rightBtnText="삭제할래"
-          />
-        );
-      case 'leenkLeave':
-        return (
-          <PopupModal
-            isOpen
-            onRightBtn={handleLeave}
-            onLeftBtn={closeModal}
-            isWarning
-            mainText="정말 떠날거야?"
-            subText={
-              leenkDetail.title.length > 10
-                ? `${leenkDetail.title.slice(0, 10)}...에서 나가지게 돼.`
-                : `${leenkDetail.title}에서 나가지게 돼.`
-            }
-            isCancel
-            leftBtnText="취소"
-            rightBtnText="나갈래"
-          />
-        );
-      case 'leenkClose':
-        return (
-          <PopupModal
-            isOpen
-            onRightBtn={handleLeenkClose}
-            onLeftBtn={closeModal}
-            isWarning
-            mainText={`아직 모임 시간이 아니야! \n모집을 종료할까?`}
-            subText="종료하면 다시 모집할 수 없어."
-            isCancel
-            leftBtnText="취소"
-            rightBtnText="종료할래"
-          />
-        );
-      case 'leenkEarlyClose':
-        return (
-          <PopupModal
-            isOpen
-            onRightBtn={handleLeenkClose}
-            onLeftBtn={closeModal}
-            mainText={`링크 시간이 아직 남았어! \n일찍 끝낼거야?`}
-            isCancel
-            leftBtnText="취소"
-            rightBtnText="삭제할래"
-          />
-        );
-      case 'leenkReport':
-        return <ReportModal type="leenk" />;
-      default:
-        return null;
-    }
-  };
+  if (isBusy || !leenkDetail) {
+    return <Loading />;
+  }
 
   return (
     <Container>
       <GradientOverlay type="top" heightValue={120 * height} />
+
       <Header
         isBackWhite
         RightSection="KEBAB"
         kebabPress={() => openModal('menu')}
-        style={{
-          position: 'absolute',
-          width: '100%',
-          zIndex: 9999,
-          paddingHorizontal: width * CONTAINER_PADDING,
-        }}
+        style={styles.header}
       />
 
       <ImageContainer>
@@ -317,21 +265,20 @@ export default function LeenkDetailPage() {
         isOneOption={!isAuthor}
       />
 
-      {renderPopupModal()}
+      <LeenkDetailModals
+        modalType={modalType as any}
+        title={leenkDetail.title}
+        onClose={closeModal}
+        onConfirmDelete={handleConfirmDelete}
+        onConfirmLeave={handleLeave}
+        onConfirmClose={handleLeenkClose}
+      />
 
       {modalType === 'bottomSheet' && (
-        <BottomSheetModal visible={true}>
+        <BottomSheetModal visible>
           <TitleText>{'링크가 마무리 됐어 :)'}</TitleText>
           <SubText>수고했어! 후기 남기러 가볼까?</SubText>
-          <ReviewIcon
-            height={200}
-            width={200}
-            style={{
-              alignSelf: 'center',
-              marginTop: 16 * height,
-              marginBottom: 40 * height,
-            }}
-          />
+          <ReviewIcon style={styles.reviewIcon} height={200} width={200} />
           <CustomButton
             fullWidth
             onPress={() => {
@@ -358,6 +305,20 @@ export default function LeenkDetailPage() {
   );
 }
 
+const styles = StyleSheet.create({
+  header: {
+    position: 'absolute',
+    width: '100%',
+    zIndex: 9999,
+    paddingHorizontal: width * CONTAINER_PADDING,
+  },
+  reviewIcon: {
+    alignSelf: 'center',
+    marginTop: 16 * height,
+    marginBottom: 40 * height,
+  },
+});
+
 const Container = styled.View`
   flex: 1;
   background-color: ${colors.white};
@@ -369,6 +330,7 @@ const ImageContainer = styled.View`
   height: ${height * 375}px;
   position: relative;
 `;
+
 const CheckerWrapper = styled.View`
   ${StyleSheet.absoluteFillObject};
   justify-content: center;

--- a/app/(post)/leenk/[id]/index.tsx
+++ b/app/(post)/leenk/[id]/index.tsx
@@ -86,8 +86,11 @@ export default function LeenkDetailPage() {
   };
 
   const handleEdit = () => {
-    //TODO:수정하기 로직 추가
     closeModal();
+    router.push({
+      pathname: '/(post)/leenk',
+      params: { mode: 'edit', leenkId: String(leenkDetail?.id ?? '') },
+    });
   };
 
   const handleReport = () => {

--- a/app/(post)/leenk/[id]/index.tsx
+++ b/app/(post)/leenk/[id]/index.tsx
@@ -53,6 +53,8 @@ export default function LeenkDetailPage() {
     () => (leenkDetail ? leenkDetail.author.userId === userInfo?.id : false),
     [leenkDetail, userInfo?.id],
   );
+
+  // console.log(isAuthor, leenkDetail?.author.userId, userInfo?.id);
   const isBusy = loading || deleting || joining || leaving;
 
   const fetchDetail = useCallback(async () => {

--- a/app/(post)/leenk/[id]/index.tsx
+++ b/app/(post)/leenk/[id]/index.tsx
@@ -229,7 +229,6 @@ export default function LeenkDetailPage() {
         )}
       </ImageContainer>
 
-      {/* pass API object directly (we refactored Section to accept { data: LeenkDetail } ) */}
       <LeenkContentSection
         data={leenkDetail}
         insetBottom={insets.bottom}

--- a/app/(post)/leenk/[id]/index.tsx
+++ b/app/(post)/leenk/[id]/index.tsx
@@ -138,7 +138,7 @@ export default function LeenkDetailPage() {
       await deleteLeenk(leenkDetail.id);
       showToast('삭제 완료!', 'success');
       closeModal();
-      router.replace('/feed');
+      router.replace('/leenk');
     } catch (err) {
       console.error('링크 삭제 오류:', err);
       showToast('삭제에 실패했어. 잠시 후 다시 시도해 줘.', 'error');
@@ -202,7 +202,7 @@ export default function LeenkDetailPage() {
         await Share.share({ message: leenkDetail.title });
       }
     } catch {
-      showToast('공유에 실패했어요', 'error');
+      showToast('공유에 실패했어', 'error');
     }
   }, [leenkDetail?.title, showToast]);
 

--- a/app/(post)/leenk/[id]/index.tsx
+++ b/app/(post)/leenk/[id]/index.tsx
@@ -49,19 +49,11 @@ export default function LeenkDetailPage() {
   const [leenkDetail, setLeenkDetail] = useState<LeenkDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [deleting, setDeleting] = useState(false);
-  const [joining, setJoining] = useState(false);
-  const [leaving, setLeaving] = useState(false);
-  const [isParticipated, setIsParticipated] = useState(
-    leenkDetail?.isParticipated,
-  );
-  const [leenkStatus, setLeenkStatus] = useState('');
 
   const isAuthor = useMemo(
     () => (leenkDetail ? leenkDetail.author.userId === userInfo?.id : false),
     [leenkDetail, userInfo?.id],
   );
-
-  const isBusy = loading || deleting || joining || leaving;
 
   const fetchDetail = useCallback(async () => {
     if (!Number.isFinite(leenkId)) {
@@ -76,7 +68,6 @@ export default function LeenkDetailPage() {
       const data = await getLeenkDetail(leenkId);
       if (active) {
         setLeenkDetail(data);
-        setLeenkStatus(data.status);
         console.log('링크의 상태:', data.status);
       }
     } catch (e) {
@@ -110,7 +101,7 @@ export default function LeenkDetailPage() {
     openModal('leenkReport');
   }, [closeModal, openModal]);
 
-  // 링크 모집 종료 함수
+  // 링크 모집 종료 함수(작성자)
   const handleLeenkClose = async (leenkId: number) => {
     try {
       await closeLeenk(leenkId);
@@ -121,7 +112,8 @@ export default function LeenkDetailPage() {
       showToast('링크 모집 종료에 실패했어요.');
     }
   };
-  // 링크 모임 종료 함수
+
+  // 링크 모임 종료 함수(작성자)
   const handleLeenkFinish = async (leenkId: number) => {
     try {
       await finishLeenk(leenkId);
@@ -181,55 +173,68 @@ export default function LeenkDetailPage() {
   }, [closeModal, router, leenkDetail?.id]);
 
   // 링크 떠나기(참여자)
-  const handleLeave = useCallback(async () => {
-    if (!leenkDetail || leaving || !isParticipated) {
-      closeModal();
-      return;
-    }
-    try {
-      setLeaving(true);
-      await leaveLeenk(leenkDetail.id);
+  const handleLeave = async () => {
+    if (!leenkDetail) return;
+    setLeenkDetail((prev) =>
+      prev
+        ? {
+            ...prev,
+            isParticipated: false,
+            currentParticipants: Math.max(prev.currentParticipants - 1, 0),
+          }
+        : prev,
+    );
 
-      // Optimistic local update
-      setIsParticipated(false);
+    try {
+      await leaveLeenk(leenkDetail.id);
+      closeModal();
+      const fresh = await getLeenkDetail(leenkDetail.id);
+      setLeenkDetail(fresh);
+    } catch (e) {
       setLeenkDetail((prev) =>
         prev
           ? {
               ...prev,
+              isParticipated: true,
+              currentParticipants: prev.currentParticipants + 1,
+            }
+          : prev,
+      );
+      showToast('나가기에 실패했어. 잠시 후 다시 시도해 줘.', 'error');
+    }
+  };
+
+  // 링크 참여하기(참여자)
+  const handleJoin = async () => {
+    if (!leenkDetail) return;
+    setLeenkDetail((prev) =>
+      prev
+        ? {
+            ...prev,
+            isParticipated: true,
+            currentParticipants: prev.currentParticipants + 1,
+          }
+        : prev,
+    );
+
+    try {
+      await participantLeenk(leenkDetail.id);
+      closeModal();
+      const fresh = await getLeenkDetail(leenkDetail.id);
+      setLeenkDetail(fresh);
+    } catch (e) {
+      setLeenkDetail((prev) =>
+        prev
+          ? {
+              ...prev,
+              isParticipated: false,
               currentParticipants: Math.max(prev.currentParticipants - 1, 0),
             }
           : prev,
       );
-      showToast('모임에서 나갔어.', 'success');
-    } catch {
-      showToast('나가기에 실패했어. 잠시 후 다시 시도해 줘.', 'error');
-    } finally {
-      setLeaving(false);
-      closeModal();
-    }
-  }, [leenkDetail, leaving, isParticipated, closeModal, showToast]);
-
-  // 링크 참여하기(참여자)
-  const handleJoinLeenk = useCallback(async () => {
-    if (!leenkDetail || joining || isParticipated) return;
-    try {
-      setJoining(true);
-      await participantLeenk(leenkDetail.id);
-
-      // Optimistic local update
-      setIsParticipated(true);
-      setLeenkDetail((prev) =>
-        prev
-          ? { ...prev, currentParticipants: prev.currentParticipants + 1 }
-          : prev,
-      );
-      showToast('참여했어!', 'success');
-    } catch {
       showToast('참여에 실패했어. 잠시 후 다시 시도해 줘.', 'error');
-    } finally {
-      setJoining(false);
     }
-  }, [leenkDetail, joining, isParticipated, showToast]);
+  };
 
   // 공유하기(작성자,침여자)
   const handleShare = async () => {
@@ -262,7 +267,7 @@ export default function LeenkDetailPage() {
     }
   };
 
-  if (isBusy || !leenkDetail) {
+  if (loading || deleting || !leenkDetail) {
     return <Loading />;
   }
 
@@ -304,7 +309,7 @@ export default function LeenkDetailPage() {
         onLeave={() => openModal('leenkLeave')}
         onFinish={() => openModal('leenkFinish')}
         onClose={() => openModal('leenkClose')}
-        onJoin={handleJoinLeenk}
+        onJoin={handleJoin}
         onParticipants={handleParticipants}
       />
 

--- a/app/(post)/leenk/[id]/index.tsx
+++ b/app/(post)/leenk/[id]/index.tsx
@@ -1,4 +1,4 @@
-import { CheckerIcon, ReviewIcon, ShareIcon } from '@/assets';
+import { CheckerIcon, ReviewIcon } from '@/assets';
 import {
   BottomSheetModal,
   CustomButton,
@@ -15,8 +15,7 @@ import colors from '@/theme/color';
 import { height, width } from '@/theme/globalStyles';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import styled from 'styled-components/native';
-// ❌ mock 삭제
-// import { mockLeenkData } from '@/constants/mockUserData';
+
 import { StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -27,8 +26,7 @@ import LeenkContentSection from '@/components/leenk/LeenkDetailContent';
 import LeenkBottomButtonSection from '@/components/leenk/LeenkDetailBottomButton';
 import ReportModal from '@/components/Modal/ReportModal';
 
-// ⬇️ API & 타입 import
-import { getLeenkDetail } from '@/api/leenk/leenk.get.api'; // 경로는 프로젝트 구조에 맞게
+import { getLeenkDetail } from '@/api/leenk/leenk.get.api';
 import { LeenkDetail } from '@/types/leenk';
 import { useUserStore } from '@/stores/userStore';
 
@@ -44,13 +42,11 @@ export default function LeenkDetailPage() {
   const [isParticipating, setIsParticipating] = useState(false);
   const [isLeenkEnd, setIsLeenkEnd] = useState(false);
 
-  // ⬇️ detail state
   const [leenkDetail, setLeenkDetail] = useState<LeenkDetail | null>(null);
   const [loading, setLoading] = useState(true);
 
   const { userInfo } = useUserStore();
 
-  // fetch detail
   useEffect(() => {
     let mounted = true;
     (async () => {
@@ -59,11 +55,10 @@ export default function LeenkDetailPage() {
         if (!Number.isFinite(leenkId)) {
           throw new Error('Invalid leenk id');
         }
-        const data = await getLeenkDetail(leenkId); // returns LeenkDetail
+        const data = await getLeenkDetail(leenkId);
         if (mounted) setLeenkDetail(data);
       } catch (e) {
         showToast('상세 정보를 불러오지 못했어.', 'error');
-        // 뒤로 이동하거나 적절한 fallback
         router.back();
       } finally {
         if (mounted) setLoading(false);
@@ -76,7 +71,6 @@ export default function LeenkDetailPage() {
 
   const isAuthor = leenkDetail?.author.userId === userInfo?.id;
 
-  // early return while fetching
   if (loading || !leenkDetail) {
     return <Loading />;
   }
@@ -122,6 +116,11 @@ export default function LeenkDetailPage() {
     setIsParticipating(false);
     closeModal();
     // TODO: 유저 나가기 api 추가
+  };
+
+  const handleJoinLeenk = () => {
+    // TODO: 링크 참여하기 api 연결
+    setIsParticipating(true);
   };
 
   const handleShare = async () => {
@@ -214,7 +213,6 @@ export default function LeenkDetailPage() {
         }}
       />
 
-      {/* top image uses API mediaUrl */}
       <ImageContainer>
         {leenkDetail.mediaUrl ? (
           <Image
@@ -243,7 +241,7 @@ export default function LeenkDetailPage() {
         onLeave={() => openModal('leenkLeave')}
         onEalryClose={() => openModal('leenkEarlyClose')}
         onClose={handleLeenkCloseModal}
-        onJoin={() => setIsParticipating(true)}
+        onJoin={handleJoinLeenk}
         onParticipants={handleParticipants}
         isLeenkEnd={isLeenkEnd}
       />

--- a/app/(post)/leenk/[id]/index.tsx
+++ b/app/(post)/leenk/[id]/index.tsx
@@ -51,9 +51,10 @@ export default function LeenkDetailPage() {
   const [deleting, setDeleting] = useState(false);
   const [joining, setJoining] = useState(false);
   const [leaving, setLeaving] = useState(false);
-  const [isParticipating, setIsParticipating] = useState(false);
+  const [isParticipated, setIsParticipated] = useState(
+    leenkDetail?.isParticipated,
+  );
   const [leenkStatus, setLeenkStatus] = useState('');
-  const [isLeenkEnd, setIsLeenkEnd] = useState(false);
 
   const isAuthor = useMemo(
     () => (leenkDetail ? leenkDetail.author.userId === userInfo?.id : false),
@@ -181,7 +182,7 @@ export default function LeenkDetailPage() {
 
   // 링크 떠나기(참여자)
   const handleLeave = useCallback(async () => {
-    if (!leenkDetail || leaving || !isParticipating) {
+    if (!leenkDetail || leaving || !isParticipated) {
       closeModal();
       return;
     }
@@ -190,7 +191,7 @@ export default function LeenkDetailPage() {
       await leaveLeenk(leenkDetail.id);
 
       // Optimistic local update
-      setIsParticipating(false);
+      setIsParticipated(false);
       setLeenkDetail((prev) =>
         prev
           ? {
@@ -206,17 +207,17 @@ export default function LeenkDetailPage() {
       setLeaving(false);
       closeModal();
     }
-  }, [leenkDetail, leaving, isParticipating, closeModal, showToast]);
+  }, [leenkDetail, leaving, isParticipated, closeModal, showToast]);
 
   // 링크 참여하기(참여자)
   const handleJoinLeenk = useCallback(async () => {
-    if (!leenkDetail || joining || isParticipating) return;
+    if (!leenkDetail || joining || isParticipated) return;
     try {
       setJoining(true);
       await participantLeenk(leenkDetail.id);
 
       // Optimistic local update
-      setIsParticipating(true);
+      setIsParticipated(true);
       setLeenkDetail((prev) =>
         prev
           ? { ...prev, currentParticipants: prev.currentParticipants + 1 }
@@ -228,7 +229,7 @@ export default function LeenkDetailPage() {
     } finally {
       setJoining(false);
     }
-  }, [leenkDetail, joining, isParticipating, showToast]);
+  }, [leenkDetail, joining, isParticipated, showToast]);
 
   // 공유하기(작성자,침여자)
   const handleShare = async () => {
@@ -296,17 +297,15 @@ export default function LeenkDetailPage() {
         onShare={handleShare}
         onParticipants={handleParticipants}
       />
-
       <LeenkBottomButtonSection
         isAuthor={isAuthor}
-        isParticipating={isParticipating}
+        leenkDetail={leenkDetail}
         insetBottom={insets.bottom}
         onLeave={() => openModal('leenkLeave')}
         onFinish={() => openModal('leenkFinish')}
         onClose={() => openModal('leenkClose')}
         onJoin={handleJoinLeenk}
         onParticipants={handleParticipants}
-        leenkStatus={leenkStatus}
       />
 
       <MenuModal
@@ -350,7 +349,6 @@ export default function LeenkDetailPage() {
             fullWidth
             onPress={() => {
               closeModal();
-              setIsLeenkEnd(true);
             }}
           >
             나중에 할래

--- a/app/(post)/leenk/[id]/index.tsx
+++ b/app/(post)/leenk/[id]/index.tsx
@@ -29,6 +29,7 @@ import ReportModal from '@/components/Modal/ReportModal';
 import { getLeenkDetail } from '@/api/leenk/leenk.get.api';
 import { LeenkDetail } from '@/types/leenk';
 import { useUserStore } from '@/stores/userStore';
+import { deleteLeenk } from '@/api/leenk/leenk.del.api';
 
 export default function LeenkDetailPage() {
   const { id } = useLocalSearchParams<{ id: string | string[] }>();
@@ -44,6 +45,7 @@ export default function LeenkDetailPage() {
 
   const [leenkDetail, setLeenkDetail] = useState<LeenkDetail | null>(null);
   const [loading, setLoading] = useState(true);
+  const [deleting, setDeleting] = useState(false);
 
   const { userInfo } = useUserStore();
 
@@ -71,7 +73,7 @@ export default function LeenkDetailPage() {
 
   const isAuthor = leenkDetail?.author.userId === userInfo?.id;
 
-  if (loading || !leenkDetail) {
+  if (loading || !leenkDetail || deleting) {
     return <Loading />;
   }
 
@@ -99,16 +101,20 @@ export default function LeenkDetailPage() {
 
   const handleConfirmDelete = async () => {
     try {
-      // TODO: 삭제 API 연동
+      if (!leenkDetail) return;
+      setDeleting(true);
+
+      await deleteLeenk(leenkDetail.id);
+
       showToast('삭제 완료!', 'success');
-      setTimeout(() => {
-        router.replace('/feed');
-      }, 1500);
+      closeModal();
+
+      router.replace('/feed');
     } catch (err: any) {
       console.error('링크 삭제 오류:', err);
-      showToast('삭제 실패!', 'error');
+      showToast('삭제에 실패했어요. 잠시 후 다시 시도해 주세요.', 'error');
     } finally {
-      closeModal();
+      setDeleting(false);
     }
   };
 

--- a/app/(post)/leenk/[id]/index.tsx
+++ b/app/(post)/leenk/[id]/index.tsx
@@ -1,11 +1,5 @@
-import { CheckerIcon, ReviewIcon } from '@/assets';
-import {
-  BottomSheetModal,
-  CustomButton,
-  Header,
-  Loading,
-  MenuModal,
-} from '@/components';
+import { CheckerIcon } from '@/assets';
+import { Header, Loading, MenuModal } from '@/components';
 import GradientOverlay from '@/components/feed/GradientOverlay';
 import { CONTAINER_PADDING } from '@/constants';
 import { useModalStore } from '@/stores/modalStore';
@@ -19,13 +13,13 @@ import { Platform, StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Share } from 'react-native';
-import { SubText, TitleText } from '@/components/OnBoarding';
+
 import { useCallback, useMemo, useState } from 'react';
 import LeenkContentSection from '@/components/leenk/LeenkDetailContent';
 import LeenkBottomButtonSection from '@/components/leenk/LeenkDetailBottomButton';
 
 import { getLeenkDetail } from '@/api/leenk/leenk.get.api';
-import { LeenkDetail } from '@/types/leenk';
+import { LeenkDetail, LeenkStatus } from '@/types/leenk';
 import { useUserStore } from '@/stores/userStore';
 import { deleteLeenk, leaveLeenk } from '@/api/leenk/leenk.del.api';
 import {
@@ -36,6 +30,7 @@ import {
 import LeenkDetailModals from '@/components/leenk/LeenkDetailModals';
 import * as Linking from 'expo-linking';
 import * as Clipboard from 'expo-clipboard';
+
 export default function LeenkDetailPage() {
   const { id } = useLocalSearchParams<{ id: string | string[] }>();
   const leenkId = useMemo(() => Number(Array.isArray(id) ? id[0] : id), [id]);
@@ -50,47 +45,52 @@ export default function LeenkDetailPage() {
   const [loading, setLoading] = useState(true);
   const [deleting, setDeleting] = useState(false);
 
+  const [pendingAction, setPendingAction] = useState<null | 'close' | 'finish'>(
+    null,
+  );
+
+  // 부분 패치 헬퍼
+  const patchDetail = useCallback((patch: Partial<LeenkDetail>) => {
+    setLeenkDetail((prev) => (prev ? { ...prev, ...patch } : prev));
+  }, []);
+
   const isAuthor = useMemo(
     () => (leenkDetail ? leenkDetail.author.userId === userInfo?.id : false),
     [leenkDetail, userInfo?.id],
   );
 
-  const fetchDetail = useCallback(async () => {
-    if (!Number.isFinite(leenkId)) {
-      showToast('잘못된 링크야.', 'error');
-      router.back();
-      return;
-    }
+  const fetchDetail = useCallback(
+    async (signal?: { canceled: boolean }) => {
+      setLoading(true);
+      try {
+        const data = await getLeenkDetail(leenkId);
+        if (!signal?.canceled) {
+          setLeenkDetail(data);
+          console.log('링크의 상태:', data.status);
+        }
+      } catch (e) {
+        if (!signal?.canceled) {
+          showToast('상세 정보를 불러오지 못했어.', 'error');
+          router.back();
+        }
+      } finally {
+        if (!signal?.canceled) setLoading(false);
+      }
+    },
+    [leenkId, router, showToast],
+  );
 
-    let active = true;
-    setLoading(true);
-    try {
-      const data = await getLeenkDetail(leenkId);
-      if (active) {
-        setLeenkDetail(data);
-        console.log('링크의 상태:', data.status);
-      }
-    } catch (e) {
-      if (active) {
-        showToast('상세 정보를 불러오지 못했어.', 'error');
-        router.back();
-      }
-    } finally {
-      if (active) setLoading(false);
-    }
-    return () => {
-      active = false;
-    };
-  }, [leenkId, router, showToast]);
+  const refetchDetail = useCallback(async () => {
+    const fresh = await getLeenkDetail(leenkId);
+    setLeenkDetail(fresh);
+  }, [leenkId]);
 
   useFocusEffect(
     useCallback(() => {
-      let cleanup: (() => void) | undefined;
-      (async () => {
-        cleanup = await fetchDetail();
-      })();
+      const signal = { canceled: false };
+      fetchDetail(signal);
       return () => {
-        cleanup?.();
+        signal.canceled = true;
       };
     }, [fetchDetail]),
   );
@@ -103,27 +103,52 @@ export default function LeenkDetailPage() {
 
   // 링크 모집 종료 함수(작성자)
   const handleLeenkClose = async (leenkId: number) => {
+    if (!leenkDetail || pendingAction) return;
+    setPendingAction('close');
+
+    // 스냅샷 저장
+    const snapshot = leenkDetail;
+
+    // 낙관적 업데이트: 상태만 최소 변경
+    patchDetail({ status: 'CLOSED' as LeenkStatus });
+
     try {
       await closeLeenk(leenkId);
       closeModal();
-      showToast('링크 모집을 종료했어요.');
+      showToast('링크 모집을 종료했어!');
     } catch (err) {
+      // 실패 롤백
+      setLeenkDetail(snapshot);
       console.error('링크 모집 종료 실패:', err);
-      showToast('링크 모집 종료에 실패했어요.');
+      showToast('링크 모집 종료에 실패했어!', 'error');
+    } finally {
+      setPendingAction(null);
     }
   };
 
   // 링크 모임 종료 함수(작성자)
   const handleLeenkFinish = async (leenkId: number) => {
+    if (!leenkDetail || pendingAction) return;
+    setPendingAction('finish');
+
+    const snapshot = leenkDetail;
+
+    // 낙관적 업데이트
+    patchDetail({ status: 'FINISHED' as LeenkStatus });
+
     try {
       await finishLeenk(leenkId);
       closeModal();
-      showToast('링크 모임을 종료했어요.');
-      // 종료 후 바텀시트 띄우기
+      showToast('링크 모임을 종료했어!');
+
+      // 성공 후 바텀시트 오픈 (성공 시점에만!)
       openModal('bottomSheet');
     } catch (err) {
+      setLeenkDetail(snapshot);
       console.error('링크 모임 종료 실패:', err);
-      showToast('링크 모임 종료에 실패했어요.');
+      showToast('링크 모임 종료에 실패했어!', 'error');
+    } finally {
+      setPendingAction(null);
     }
   };
 
@@ -172,34 +197,28 @@ export default function LeenkDetailPage() {
     });
   }, [closeModal, router, leenkDetail?.id]);
 
-  // 링크 떠나기(참여자)
-  const handleLeave = async () => {
-    if (!leenkDetail) return;
+  const applyParticipatePatch = (delta: 1 | -1, flag: boolean) => {
     setLeenkDetail((prev) =>
       prev
         ? {
             ...prev,
-            isParticipated: false,
-            currentParticipants: Math.max(prev.currentParticipants - 1, 0),
+            isParticipated: flag,
+            currentParticipants: Math.max(prev.currentParticipants + delta, 0),
           }
         : prev,
     );
+  };
 
+  // 링크 떠나기(참여자)
+  const handleLeave = async () => {
+    if (!leenkDetail) return;
+    applyParticipatePatch(-1, false);
     try {
       await leaveLeenk(leenkDetail.id);
       closeModal();
-      const fresh = await getLeenkDetail(leenkDetail.id);
-      setLeenkDetail(fresh);
-    } catch (e) {
-      setLeenkDetail((prev) =>
-        prev
-          ? {
-              ...prev,
-              isParticipated: true,
-              currentParticipants: prev.currentParticipants + 1,
-            }
-          : prev,
-      );
+      await refetchDetail();
+    } catch {
+      applyParticipatePatch(+1, true);
       showToast('나가기에 실패했어. 잠시 후 다시 시도해 줘.', 'error');
     }
   };
@@ -207,31 +226,13 @@ export default function LeenkDetailPage() {
   // 링크 참여하기(참여자)
   const handleJoin = async () => {
     if (!leenkDetail) return;
-    setLeenkDetail((prev) =>
-      prev
-        ? {
-            ...prev,
-            isParticipated: true,
-            currentParticipants: prev.currentParticipants + 1,
-          }
-        : prev,
-    );
-
+    applyParticipatePatch(+1, true);
     try {
       await participantLeenk(leenkDetail.id);
       closeModal();
-      const fresh = await getLeenkDetail(leenkDetail.id);
-      setLeenkDetail(fresh);
-    } catch (e) {
-      setLeenkDetail((prev) =>
-        prev
-          ? {
-              ...prev,
-              isParticipated: false,
-              currentParticipants: Math.max(prev.currentParticipants - 1, 0),
-            }
-          : prev,
-      );
+      await refetchDetail();
+    } catch {
+      applyParticipatePatch(-1, false);
       showToast('참여에 실패했어. 잠시 후 다시 시도해 줘.', 'error');
     }
   };
@@ -279,7 +280,12 @@ export default function LeenkDetailPage() {
         isBackWhite
         RightSection="KEBAB"
         kebabPress={() => openModal('menu')}
-        style={styles.header}
+        style={{
+          position: 'absolute',
+          width: '100%',
+          zIndex: 9999,
+          paddingHorizontal: width * CONTAINER_PADDING,
+        }}
       />
 
       <ImageContainer>
@@ -333,50 +339,9 @@ export default function LeenkDetailPage() {
         onConfirmClose={() => handleLeenkClose(leenkDetail.id)}
         onConfirmFinish={() => handleLeenkFinish(leenkDetail.id)}
       />
-
-      {modalType === 'bottomSheet' && (
-        <BottomSheetModal visible>
-          <TitleText>{'링크가 마무리 됐어 :)'}</TitleText>
-          <SubText>수고했어! 후기 남기러 가볼까?</SubText>
-          <ReviewIcon style={styles.reviewIcon} height={200} width={200} />
-          <CustomButton
-            fullWidth
-            onPress={() => {
-              closeModal();
-              router.push('/feed');
-            }}
-          >
-            후기 쓰러갈래
-          </CustomButton>
-          <CustomButton
-            variant="text"
-            textColor="text[2]"
-            fullWidth
-            onPress={() => {
-              closeModal();
-            }}
-          >
-            나중에 할래
-          </CustomButton>
-        </BottomSheetModal>
-      )}
     </Container>
   );
 }
-
-const styles = StyleSheet.create({
-  header: {
-    position: 'absolute',
-    width: '100%',
-    zIndex: 9999,
-    paddingHorizontal: width * CONTAINER_PADDING,
-  },
-  reviewIcon: {
-    alignSelf: 'center',
-    marginTop: 16 * height,
-    marginBottom: 40 * height,
-  },
-});
 
 const Container = styled.View`
   flex: 1;

--- a/app/(post)/leenk/[id]/index.tsx
+++ b/app/(post)/leenk/[id]/index.tsx
@@ -15,44 +15,71 @@ import colors from '@/theme/color';
 import { height, width } from '@/theme/globalStyles';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import styled from 'styled-components/native';
-import { mockLeenkData } from '@/constants/mockUserData';
+// ❌ mock 삭제
+// import { mockLeenkData } from '@/constants/mockUserData';
 import { StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Share } from 'react-native';
 import { SubText, TitleText } from '@/components/OnBoarding';
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import LeenkContentSection from '@/components/leenk/LeenkDetailContent';
 import LeenkBottomButtonSection from '@/components/leenk/LeenkDetailBottomButton';
 import ReportModal from '@/components/Modal/ReportModal';
 
+// ⬇️ API & 타입 import
+import { getLeenkDetail } from '@/api/leenk/leenk.get.api'; // 경로는 프로젝트 구조에 맞게
+import { LeenkDetail } from '@/types/leenk';
+import { useUserStore } from '@/stores/userStore';
+
 export default function LeenkDetailPage() {
   const { id } = useLocalSearchParams<{ id: string | string[] }>();
-  const leenkId = Array.isArray(id) ? id[0] : id;
+  const leenkId = useMemo(() => Number(Array.isArray(id) ? id[0] : id), [id]);
+
   const { modalType, openModal, closeModal } = useModalStore();
   const { showToast } = useToastStore();
   const router = useRouter();
   const insets = useSafeAreaInsets();
+
   const [isParticipating, setIsParticipating] = useState(false);
   const [isLeenkEnd, setIsLeenkEnd] = useState(false);
 
-  const isAuthor = true;
-  const leenkData = mockLeenkData.find((item) => item.id === leenkId);
+  // ⬇️ detail state
+  const [leenkDetail, setLeenkDetail] = useState<LeenkDetail | null>(null);
+  const [loading, setLoading] = useState(true);
 
-  if (!leenkData) return <Loading />;
+  const { userInfo } = useUserStore();
 
-  const {
-    title,
-    place,
-    content,
-    date,
-    name,
-    createdAt,
-    profileImageUri,
-    participantCount,
-    allParticipants,
-    leenkImageUri,
-  } = leenkData;
+  // fetch detail
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        if (!Number.isFinite(leenkId)) {
+          throw new Error('Invalid leenk id');
+        }
+        const data = await getLeenkDetail(leenkId); // returns LeenkDetail
+        if (mounted) setLeenkDetail(data);
+      } catch (e) {
+        showToast('상세 정보를 불러오지 못했어.', 'error');
+        // 뒤로 이동하거나 적절한 fallback
+        router.back();
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [leenkId]);
+
+  const isAuthor = leenkDetail?.author.userId === userInfo?.id;
+
+  // early return while fetching
+  if (loading || !leenkDetail) {
+    return <Loading />;
+  }
 
   const handleDelete = () => {
     closeModal();
@@ -78,6 +105,7 @@ export default function LeenkDetailPage() {
 
   const handleConfirmDelete = async () => {
     try {
+      // TODO: 삭제 API 연동
       showToast('삭제 완료!', 'success');
       setTimeout(() => {
         router.replace('/feed');
@@ -98,7 +126,7 @@ export default function LeenkDetailPage() {
 
   const handleShare = async () => {
     try {
-      await Share.share({ message: title });
+      await Share.share({ message: leenkDetail.title });
     } catch (error) {
       showToast('공유에 실패했어요', 'error');
     }
@@ -129,9 +157,9 @@ export default function LeenkDetailPage() {
             isWarning
             mainText="정말 떠날거야?"
             subText={
-              title.length > 10
-                ? `${title.slice(0, 10)}...에서 나가지게 돼.`
-                : `${title}에서 나가지게 돼.`
+              leenkDetail.title.length > 10
+                ? `${leenkDetail.title.slice(0, 10)}...에서 나가지게 돼.`
+                : `${leenkDetail.title}에서 나가지게 돼.`
             }
             isCancel
             leftBtnText="취소"
@@ -165,7 +193,7 @@ export default function LeenkDetailPage() {
           />
         );
       case 'leenkReport':
-        return <ReportModal type="leenk" />; // TODO : 신고하기 api 연결 시 linkId 추가
+        return <ReportModal type="leenk" />;
       default:
         return null;
     }
@@ -185,10 +213,12 @@ export default function LeenkDetailPage() {
           paddingHorizontal: width * CONTAINER_PADDING,
         }}
       />
+
+      {/* top image uses API mediaUrl */}
       <ImageContainer>
-        {leenkImageUri ? (
+        {leenkDetail.mediaUrl ? (
           <Image
-            source={{ uri: leenkImageUri }}
+            source={{ uri: leenkDetail.mediaUrl }}
             style={StyleSheet.absoluteFillObject}
             contentFit="cover"
           />
@@ -199,16 +229,9 @@ export default function LeenkDetailPage() {
         )}
       </ImageContainer>
 
+      {/* pass API object directly (we refactored Section to accept { data: LeenkDetail } ) */}
       <LeenkContentSection
-        title={title}
-        place={place}
-        content={content}
-        date={date}
-        name={name}
-        createdAt={createdAt}
-        profileImageUri={profileImageUri}
-        participantCount={participantCount}
-        allParticipants={allParticipants}
+        data={leenkDetail}
         insetBottom={insets.bottom}
         onShare={handleShare}
         onParticipants={handleParticipants}

--- a/app/(post)/leenk/participants-list/index.tsx
+++ b/app/(post)/leenk/participants-list/index.tsx
@@ -42,7 +42,6 @@ export default function ParticipantsList() {
   const [participants, setParticipants] = useState<LeenkParticipantItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
-
   const load = useCallback(async () => {
     try {
       if (!Number.isFinite(parsedId)) throw new Error('Invalid leenkId');
@@ -75,7 +74,6 @@ export default function ParticipantsList() {
     }
   };
 
-  // 첫 항목 기준으로 인원수 표시, 없으면 0/0
   const { currentCount } = useMemo(() => {
     const first = participants[0];
     return {
@@ -88,13 +86,26 @@ export default function ParticipantsList() {
     startSelection();
   };
 
+  const isKickDisabled = useMemo(() => {
+    return (
+      userIsAuthor &&
+      participants.length === 1 &&
+      participants[0]?.isHost === true
+    );
+  }, [userIsAuthor, participants]);
+
   const keyExtractor = (item: LeenkParticipantItem) =>
     String(item.participant.userId);
 
   return (
     <Container>
       {userIsAuthor ? (
-        <Header RightSection="KICK" kebabPress={handleKick}>
+        <Header
+          RightSection="KICK"
+          kebabPress={handleKick}
+          rightDisabled={isKickDisabled}
+          leenkId={parsedId}
+        >
           참여자
         </Header>
       ) : (

--- a/app/(post)/leenk/participants-list/index.tsx
+++ b/app/(post)/leenk/participants-list/index.tsx
@@ -123,7 +123,9 @@ export default function ParticipantsList() {
       <RowWrapper>
         <PeopleIcon width={width * 16} />
         <CountText>
-          {currentCount}/{maxCountFromRoute}명
+          {maxCountFromRoute != null
+            ? `${currentCount}/${maxCountFromRoute}명`
+            : `${currentCount}명`}
         </CountText>
       </RowWrapper>
 

--- a/app/(post)/leenk/participants-list/index.tsx
+++ b/app/(post)/leenk/participants-list/index.tsx
@@ -23,8 +23,13 @@ import { getLeenkParticipants } from '@/api/leenk/leenk.get.api';
 import { LeenkParticipantItem } from '@/types/leenk';
 
 export default function ParticipantsList() {
-  const { startSelection, isSelectionMode, resetSelection } =
-    useParticipantStore();
+  const {
+    startSelection,
+    isSelectionMode,
+    participants,
+    setParticipants,
+    resetSelection,
+  } = useParticipantStore();
   const { leenkId, isAuthor, maxParticipants } = useLocalSearchParams<{
     leenkId: string;
     isAuthor?: string;
@@ -39,7 +44,6 @@ export default function ParticipantsList() {
   const insets = useSafeAreaInsets();
   const { showToast } = useToastStore();
 
-  const [participants, setParticipants] = useState<LeenkParticipantItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const load = useCallback(async () => {
@@ -74,12 +78,8 @@ export default function ParticipantsList() {
     }
   };
 
-  const { currentCount } = useMemo(() => {
-    const first = participants[0];
-    return {
-      currentCount: first?.currentParticipants ?? 0,
-    };
-  }, [participants]);
+  // 서버 필드가 정확 카운트가 아니라면 일단 길이 사용
+  const currentCount = participants.length;
 
   const handleKick = () => {
     if (!userIsAuthor) return;

--- a/app/(post)/leenk/participants-list/index.tsx
+++ b/app/(post)/leenk/participants-list/index.tsx
@@ -2,7 +2,6 @@ import { PeopleIcon } from '@/assets';
 import { Header } from '@/components';
 import UserItem from '@/components/leenk/UserItem';
 import { CONTAINER_PADDING } from '@/constants';
-import { mockLeenkData } from '@/constants/mockUserData';
 import colors from '@/theme/color';
 import {
   fonts,
@@ -11,31 +10,90 @@ import {
   lineHeight,
   width,
 } from '@/theme/globalStyles';
-import { FlatList } from 'react-native-gesture-handler';
 import styled from 'styled-components/native';
 
 import { useParticipantStore } from '@/stores/participantStore';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useLocalSearchParams } from 'expo-router';
+import { useEffect, useMemo, useState, useCallback } from 'react';
+import { FlatList, RefreshControl } from 'react-native';
+import { useToastStore } from '@/stores/toastStore';
+
+import { getLeenkParticipants } from '@/api/leenk/leenk.get.api';
+import { LeenkParticipantItem } from '@/types/leenk';
 
 export default function ParticipantsList() {
-  const { selectedUsers, startSelection, isSelectionMode } =
+  const { startSelection, isSelectionMode, resetSelection } =
     useParticipantStore();
-
-  const users = mockLeenkData;
-  const isAuthor = true;
+  const { leenkId, isAuthor, maxParticipants } = useLocalSearchParams<{
+    leenkId: string;
+    isAuthor?: string;
+    maxParticipants: string;
+  }>();
+  const parsedId = Number(leenkId);
+  const userIsAuthor = isAuthor === 'true';
+  const maxCountFromRoute = maxParticipants
+    ? Number(maxParticipants)
+    : undefined;
 
   const insets = useSafeAreaInsets();
+  const { showToast } = useToastStore();
+
+  const [participants, setParticipants] = useState<LeenkParticipantItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      if (!Number.isFinite(parsedId)) throw new Error('Invalid leenkId');
+      setLoading(true);
+      const list = await getLeenkParticipants(parsedId);
+      setParticipants(list);
+      resetSelection();
+    } catch (e) {
+      console.error('참여자 목록 불러오기 실패:', e);
+      showToast('참여자 목록을 불러오지 못했어.', 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, [parsedId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const onRefresh = async () => {
+    try {
+      setRefreshing(true);
+      const list = await getLeenkParticipants(parsedId);
+      setParticipants(list);
+      resetSelection();
+    } catch (e) {
+      showToast('다시 시도해줘.', 'error');
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  // 첫 항목 기준으로 인원수 표시, 없으면 0/0
+  const { currentCount } = useMemo(() => {
+    const first = participants[0];
+    return {
+      currentCount: first?.currentParticipants ?? 0,
+    };
+  }, [participants]);
 
   const handleKick = () => {
+    if (!userIsAuthor) return;
     startSelection();
   };
 
-  console.log('선택 모드:', isSelectionMode);
+  const keyExtractor = (item: LeenkParticipantItem) =>
+    String(item.participant.userId);
 
-  console.log('내보내기 참여자:', selectedUsers);
   return (
     <Container>
-      {isAuthor ? (
+      {userIsAuthor ? (
         <Header RightSection="KICK" kebabPress={handleKick}>
           참여자
         </Header>
@@ -43,7 +101,7 @@ export default function ParticipantsList() {
         <Header>참여자</Header>
       )}
 
-      {isAuthor && (
+      {userIsAuthor && (
         <InfoText>
           {isSelectionMode
             ? '내보낼 참여자를 선택해 줘'
@@ -53,17 +111,26 @@ export default function ParticipantsList() {
 
       <RowWrapper>
         <PeopleIcon width={width * 16} />
-        <CountText>3/4명</CountText>
+        <CountText>
+          {currentCount}/{maxCountFromRoute}명
+        </CountText>
       </RowWrapper>
 
       <FlatList
-        data={users}
-        keyExtractor={(item) => item.id.toString()}
+        data={participants}
+        keyExtractor={keyExtractor}
         contentContainerStyle={{
-          paddingBottom: insets.bottom,
+          paddingBottom: insets.bottom + 16,
+          flexGrow: 1,
         }}
         renderItem={({ item }) => <UserItem user={item} />}
         showsVerticalScrollIndicator={false}
+        ListEmptyComponent={
+          !loading ? <EmptyText>아직 참여자가 없어.</EmptyText> : null
+        }
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+        }
       />
     </Container>
   );
@@ -72,6 +139,7 @@ export default function ParticipantsList() {
 const Container = styled.View`
   flex: 1;
   padding-horizontal: ${CONTAINER_PADDING};
+  background-color: ${colors.white};
 `;
 
 const InfoText = styled.Text`
@@ -94,5 +162,13 @@ const CountText = styled.Text`
   font-family: ${fonts.Regular};
   color: ${colors.text[3]};
   line-height: ${lineHeight.s}px;
+  font-size: ${fontSize.sm}px;
+`;
+
+const EmptyText = styled.Text`
+  text-align: center;
+  margin-top: ${height * 40}px;
+  color: ${colors.text[3]};
+  font-family: ${fonts.Regular};
   font-size: ${fontSize.sm}px;
 `;

--- a/app/account/my-leenk.tsx
+++ b/app/account/my-leenk.tsx
@@ -1,5 +1,106 @@
-import LeenkPage from '@/app/(page)/leenk';
+// MyLeenkPage.tsx
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { View } from 'react-native';
+import { ContainerWithNoPadding } from './my-feed';
+import { Header, Loading } from '@/components';
+import { FEED_PADDING } from '@/constants';
+import { width } from '@/theme/globalStyles';
+import { LeenkList, Separator } from '../(page)/leenk';
+import LeenkListItem from '@/components/leenk/LeenkListItem';
+import { getMyLeenkList } from '@/api/leenk/leenk.get.api';
+import { Leenk } from '@/types/leenk';
+
+const PAGE_SIZE = 10;
 
 export default function MyLeenkPage() {
-  return <LeenkPage />;
+  // 리스트 데이터 상태
+  const [data, setData] = useState<Leenk[]>([]);
+  const [page, setPage] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
+
+  // UI 상태
+  const [loading, setLoading] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+
+  // 모멘텀 스크롤 중복 호출 방지용 ref
+  const onEndReachedCalledDuringMomentum = useRef(false);
+
+  // 특정 페이지 로드
+  const loadPage = useCallback(
+    async (nextPage: number, replace = false) => {
+      // 이미 로딩 중이면 중복 호출 방지
+      if (loading) return;
+
+      setLoading(true);
+      try {
+        const res = await getMyLeenkList(nextPage, PAGE_SIZE);
+
+        const pageItems: Leenk[] =
+          (res as any)?.data?.leenks ?? (res as any)?.data?.content ?? [];
+
+        // 다음 페이지가 있는지 여부 판단 (단순 길이 기반)
+        const reachedEnd = pageItems.length < PAGE_SIZE;
+
+        setData((prev) => (replace ? pageItems : [...prev, ...pageItems]));
+        setHasMore(!reachedEnd);
+        setPage(nextPage);
+      } catch (e) {
+        if (__DEV__) console.warn('참여한 링크 조회 실패:', e);
+      } finally {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    },
+    [loading],
+  );
+
+  // 당겨서 새로고침
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    setHasMore(true);
+    onEndReachedCalledDuringMomentum.current = false;
+    await loadPage(0, true);
+  }, [loadPage]);
+
+  // 무한 스크롤
+  const onEndReached = useCallback(() => {
+    // 모멘텀 중복 호출 방지
+    if (onEndReachedCalledDuringMomentum.current) return;
+    if (!loading && hasMore) {
+      onEndReachedCalledDuringMomentum.current = true;
+      loadPage(page + 1);
+    }
+  }, [hasMore, loadPage, loading, page]);
+
+  // 첫 페이지 자동 로드
+  useEffect(() => {
+    loadPage(0, true);
+  }, [loadPage]);
+
+  return (
+    <ContainerWithNoPadding>
+      <View style={{ paddingHorizontal: FEED_PADDING * width }}>
+        <Header>참여한 모임</Header>
+      </View>
+
+      <LeenkList
+        data={data}
+        keyExtractor={(item) => String(item.leenkId)}
+        renderItem={({ item }) => <LeenkListItem item={item} />}
+        ItemSeparatorComponent={() => <Separator />}
+        showsVerticalScrollIndicator
+        // 새로고침
+        refreshing={refreshing}
+        onRefresh={onRefresh}
+        // 무한 스크롤
+        onEndReachedThreshold={0.6}
+        onEndReached={onEndReached}
+        onMomentumScrollBegin={() => {
+          onEndReachedCalledDuringMomentum.current = false;
+        }}
+        // 푸터 (로딩 중, 더 이상 데이터 없음 표시를 필요에 맞게 교체 가능)
+        ListFooterComponent={loading ? <Loading /> : !hasMore ? <View /> : null}
+      />
+    </ContainerWithNoPadding>
+  );
 }

--- a/app/account/my-leenk.tsx
+++ b/app/account/my-leenk.tsx
@@ -2,13 +2,14 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { View } from 'react-native';
 import { ContainerWithNoPadding } from './my-feed';
-import { Header, Loading } from '@/components';
+import { Header } from '@/components';
 import { FEED_PADDING } from '@/constants';
-import { width } from '@/theme/globalStyles';
+import { height, width } from '@/theme/globalStyles';
 import { LeenkList, Separator } from '../(page)/leenk';
 import LeenkListItem from '@/components/leenk/LeenkListItem';
 import { getMyLeenkList } from '@/api/leenk/leenk.get.api';
 import { Leenk } from '@/types/leenk';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 const PAGE_SIZE = 10;
 
@@ -83,24 +84,25 @@ export default function MyLeenkPage() {
         <Header>참여한 모임</Header>
       </View>
 
-      <LeenkList
-        data={data}
-        keyExtractor={(item) => String(item.leenkId)}
-        renderItem={({ item }) => <LeenkListItem item={item} />}
-        ItemSeparatorComponent={() => <Separator />}
-        showsVerticalScrollIndicator
-        // 새로고침
-        refreshing={refreshing}
-        onRefresh={onRefresh}
-        // 무한 스크롤
-        onEndReachedThreshold={0.6}
-        onEndReached={onEndReached}
-        onMomentumScrollBegin={() => {
-          onEndReachedCalledDuringMomentum.current = false;
-        }}
-        // 푸터 (로딩 중, 더 이상 데이터 없음 표시를 필요에 맞게 교체 가능)
-        ListFooterComponent={loading ? <Loading /> : !hasMore ? <View /> : null}
-      />
+      <SafeAreaView edges={['bottom']} style={{ flex: 1 }}>
+        <LeenkList
+          data={data}
+          keyExtractor={(item) => String(item.leenkId)}
+          renderItem={({ item }) => <LeenkListItem item={item} />}
+          ItemSeparatorComponent={() => <Separator />}
+          showsVerticalScrollIndicator
+          refreshing={refreshing}
+          onRefresh={onRefresh}
+          onEndReachedThreshold={0.6}
+          onEndReached={onEndReached}
+          onMomentumScrollBegin={() => {
+            onEndReachedCalledDuringMomentum.current = false;
+          }}
+          // 리스트 여백은 contentContainerStyle 쪽이 더 안전
+          contentContainerStyle={{ paddingBottom: height * 20 }}
+          ListFooterComponent={loading ? <View /> : !hasMore ? <View /> : null}
+        />
+      </SafeAreaView>
     </ContainerWithNoPadding>
   );
 }

--- a/app/account/my-leenk.tsx
+++ b/app/account/my-leenk.tsx
@@ -36,8 +36,7 @@ export default function MyLeenkPage() {
       try {
         const res = await getMyLeenkList(nextPage, PAGE_SIZE);
 
-        const pageItems: Leenk[] =
-          (res as any)?.data?.leenks ?? (res as any)?.data?.content ?? [];
+        const pageItems: Leenk[] = res.leenks ?? [];
 
         // 다음 페이지가 있는지 여부 판단 (단순 길이 기반)
         const reachedEnd = pageItems.length < PAGE_SIZE;

--- a/app/account/setting/help.tsx
+++ b/app/account/setting/help.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
-  KeyboardAvoidingView,
   Platform,
   Animated,
-  ScrollView,
   View,
+  InputAccessoryView,
+  Keyboard,
 } from 'react-native';
 import styled from 'styled-components/native';
 import { useRouter } from 'expo-router';
@@ -21,9 +21,29 @@ export default function HelpPage() {
   const [feedback, setFeedback] = useState('');
   const { showToast } = useToastStore();
   const insets = useSafeAreaInsets();
-  const buttonTranslateY = useKeyboardAnimation(
-    Platform.OS === 'ios' ? -290 : 10, // 임시 해결 ..
-  );
+
+  const isIOS = Platform.OS === 'ios';
+  const androidTranslateY = useKeyboardAnimation(12);
+
+  // iOS 키보드 상태
+  const [kbVisible, setKbVisible] = useState(false);
+
+  useEffect(() => {
+    if (!isIOS) return;
+    const show = Keyboard.addListener('keyboardWillShow', () =>
+      setKbVisible(true),
+    );
+    const hide = Keyboard.addListener('keyboardWillHide', () =>
+      setKbVisible(false),
+    );
+    return () => {
+      show.remove();
+      hide.remove();
+    };
+  }, [isIOS]);
+
+  const disabled = feedback.trim() === '';
+  const ACCESSORY_ID = 'help-feedback-accessory';
 
   const handleConfirm = async () => {
     try {
@@ -35,42 +55,98 @@ export default function HelpPage() {
     }
   };
 
+  const contentPaddingBottom = isIOS
+    ? kbVisible
+      ? 4
+      : insets.bottom + 72
+    : 120 * height;
+
   return (
-    <KeyboardAvoidingView
-      style={{ flex: 1 }}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      keyboardVerticalOffset={0}
-    >
-      <Wrapper>
-        <ScrollContainer
-          contentContainerStyle={{
-            paddingBottom: 160 * height,
-          }}
-          keyboardShouldPersistTaps="handled"
-        >
-          <Header>의견 남기기</Header>
+    <Wrapper>
+      <ScrollContainer
+        automaticallyAdjustKeyboardInsets={false}
+        keyboardDismissMode="interactive"
+        contentInsetAdjustmentBehavior={isIOS ? 'never' : 'automatic'}
+        contentContainerStyle={{ paddingBottom: contentPaddingBottom }}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Header>의견 남기기</Header>
 
-          <MarginContainer>
-            <Textarea
-              title="LEENK에 대한 의견을 입력해줘"
-              placeholder="텍스트를 입력해 주세요"
-              maxLength={200}
-              subMessage="불편한 점, 좋은 점 등 자유로운 의견을 적어줘"
-              minHeight={1}
-              value={feedback}
-              onChangeText={setFeedback}
-            />
-          </MarginContainer>
-        </ScrollContainer>
+        <MarginContainer>
+          <Textarea
+            title="LEENK에 대한 의견을 입력해줘"
+            placeholder="텍스트를 입력해 주세요"
+            maxLength={200}
+            subMessage="불편한 점, 좋은 점 등 자유로운 의견을 적어줘"
+            minHeight={30}
+            value={feedback}
+            onChangeText={setFeedback}
+            accessoryID={isIOS ? ACCESSORY_ID : undefined}
+          />
+        </MarginContainer>
+      </ScrollContainer>
 
+      {isIOS ? (
+        <>
+          {!kbVisible && (
+            <View
+              style={{
+                position: 'absolute',
+                left: 0,
+                right: 0,
+                bottom: insets.bottom + 8,
+                paddingHorizontal: 20 * width,
+                backgroundColor: 'transparent',
+              }}
+            >
+              <CustomButton
+                variant="primary"
+                fullWidth
+                size="lg"
+                onPress={handleConfirm}
+                disabled={disabled}
+              >
+                제출하기
+              </CustomButton>
+            </View>
+          )}
+
+          {/* iOS: 키보드가 열리면 InputAccessoryView로 동일 버튼을 키보드 바로 위에 표시 */}
+          <InputAccessoryView
+            nativeID={ACCESSORY_ID}
+            backgroundColor={colors.bg[2]}
+          >
+            <View
+              style={{
+                paddingHorizontal: 20 * width,
+                paddingTop: 8,
+                paddingBottom: insets.bottom + 8,
+                backgroundColor: colors.bg[2],
+                marginBottom: -25 * height,
+              }}
+            >
+              <CustomButton
+                variant="primary"
+                fullWidth
+                size="lg"
+                onPress={handleConfirm}
+                disabled={disabled}
+              >
+                제출하기
+              </CustomButton>
+            </View>
+          </InputAccessoryView>
+        </>
+      ) : (
+        // Android
         <Animated.View
           style={{
             position: 'absolute',
-            bottom: insets.bottom,
             left: 0,
             right: 0,
-            transform: [{ translateY: buttonTranslateY }],
+            bottom: insets.bottom + 8,
             paddingHorizontal: 20 * width,
+            transform: [{ translateY: androidTranslateY }],
           }}
         >
           <CustomButton
@@ -78,13 +154,13 @@ export default function HelpPage() {
             fullWidth
             size="lg"
             onPress={handleConfirm}
-            disabled={feedback.trim() === ''}
+            disabled={disabled}
           >
             제출하기
           </CustomButton>
         </Animated.View>
-      </Wrapper>
-    </KeyboardAvoidingView>
+      )}
+    </Wrapper>
   );
 }
 
@@ -96,6 +172,7 @@ const Wrapper = styled.View`
 const ScrollContainer = styled.ScrollView`
   flex: 1;
   padding: 0 ${20 * width}px;
+  background-color: transparent;
 `;
 
 const MarginContainer = styled.View`

--- a/app/signup/profile.tsx
+++ b/app/signup/profile.tsx
@@ -19,11 +19,6 @@ import ProfileTitleText from '@/components/signup/ProfileTitleText';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import useKeyboardAnimation from '@/hooks/useKeyboardAnimation';
 import { useToastStore } from '@/stores/toastStore';
-import {
-  deleteTempAccessToken,
-  getTempAccessToken,
-  saveAccessToken,
-} from '@/utils/tokenStorage';
 import { registerFcmToken } from '@/components/LandingPage';
 
 export default function ProfilePage() {
@@ -48,14 +43,6 @@ export default function ProfilePage() {
   const buttonTranslateY = useKeyboardAnimation(10);
 
   const { showToast } = useToastStore();
-
-  // const commitTempAccessToken = async () => {
-  //   const tempToken = await getTempAccessToken();
-  //   if (!tempToken) return;
-
-  //   await saveAccessToken(tempToken);
-  //   await deleteTempAccessToken();
-  // };
 
   // 프로필 저장 함수
   const saveProfile = async () => {

--- a/app/signup/profile.tsx
+++ b/app/signup/profile.tsx
@@ -49,13 +49,13 @@ export default function ProfilePage() {
 
   const { showToast } = useToastStore();
 
-  const commitTempAccessToken = async () => {
-    const tempToken = await getTempAccessToken();
-    if (!tempToken) return;
+  // const commitTempAccessToken = async () => {
+  //   const tempToken = await getTempAccessToken();
+  //   if (!tempToken) return;
 
-    await saveAccessToken(tempToken);
-    await deleteTempAccessToken();
-  };
+  //   await saveAccessToken(tempToken);
+  //   await deleteTempAccessToken();
+  // };
 
   // 프로필 저장 함수
   const saveProfile = async () => {
@@ -110,7 +110,7 @@ export default function ProfilePage() {
     } else {
       try {
         await saveProfile();
-        await commitTempAccessToken();
+        // await commitTempAccessToken();
         await registerFcmToken();
         router.replace('/(page)/feed');
       } catch (e) {
@@ -133,7 +133,7 @@ export default function ProfilePage() {
     } catch (error) {
       console.error('[handleSkip] 실패:', error);
     }
-    await commitTempAccessToken();
+    // await commitTempAccessToken();
     await registerFcmToken();
     router.replace('/(page)/feed');
   };

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -17,6 +17,7 @@ import PopupModal from '@/components/Modal/PopupModal';
 import { Linking } from 'react-native';
 import { kakaoLogin } from '@/api/login/kakao.api';
 import {
+  clearAllTokens,
   getFcmToken,
   saveAccessToken,
   saveRefreshToken,
@@ -52,6 +53,7 @@ export default function LandingPage() {
   useBlockBackHandler({ block: shouldBlock });
 
   const handleKakaoLogin = async () => {
+    await clearAllTokens();
     //카카오 로그인 로직
     try {
       const token = await login();

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -21,7 +21,6 @@ import {
   getFcmToken,
   saveAccessToken,
   saveRefreshToken,
-  saveTempAccessToken,
 } from '@/utils/tokenStorage';
 import { useProfileStore } from '@/stores/profileStore';
 import { useBlockBackHandler } from '@/hooks/useBlockBackHandler';
@@ -69,7 +68,7 @@ export default function LandingPage() {
         const refreshToken = result.data.refreshToken;
 
         if (result.code === 1002) {
-          await saveTempAccessToken(result.data.accessToken);
+          await saveAccessToken(serverToken);
           await saveRefreshToken(refreshToken);
           setName(result.data.name);
           setPosition(result.data.position);
@@ -78,21 +77,8 @@ export default function LandingPage() {
           router.push('/signup/terms');
         } else if (result.code === 1003) {
           // 일반 로그인: 바로 피드로 이동
-
-          // 문자열이 아닐 경우 강제로 stringify하거나 에러 방어
-          if (
-            typeof serverToken === 'string' &&
-            typeof refreshToken === 'string'
-          ) {
-            await saveAccessToken(serverToken);
-            await saveRefreshToken(refreshToken);
-          } else {
-            console.error('❗ serverToken 또는 refreshToken이 문자열이 아님:', {
-              serverToken,
-              refreshToken,
-            });
-          }
-
+          await saveAccessToken(serverToken);
+          await saveRefreshToken(refreshToken);
           await registerFcmToken();
           router.replace('/(page)/feed');
         }

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -12,7 +12,7 @@ import colors from '@/theme/color';
 import KakaoLogo from '@/assets/images/ic_KAKAO_symbol.svg';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { CustomButton } from '@/components';
-import { login, logout } from '@react-native-kakao/user';
+import { login } from '@react-native-kakao/user';
 import PopupModal from '@/components/Modal/PopupModal';
 import { Linking } from 'react-native';
 import { kakaoLogin } from '@/api/login/kakao.api';
@@ -60,10 +60,6 @@ export default function LandingPage() {
         if (__DEV__) console.warn('카카오 accessToken 없음(취소/실패)');
         return;
       }
-
-      // 이메일 정보 조회
-      // const userInfo = await getKakaoUserInfo(accessToken);
-      // console.log('사용자 이메일:', userInfo.kakao_account.email);
       const result = await kakaoLogin(accessToken);
 
       if (result.success) {
@@ -80,18 +76,6 @@ export default function LandingPage() {
           router.push('/signup/terms');
         } else if (result.code === 1003) {
           // 일반 로그인: 바로 피드로 이동
-          if (__DEV__) {
-            console.log('[secureStore 전에] serverToken:', serverToken);
-            console.log(
-              '[secureStore 전에] typeof serverToken:',
-              typeof serverToken,
-            );
-            console.log('[secureStore 전에] refreshToken:', refreshToken);
-            console.log(
-              '[secureStore 전에] typeof refreshToken:',
-              typeof refreshToken,
-            );
-          }
 
           // 문자열이 아닐 경우 강제로 stringify하거나 에러 방어
           if (
@@ -109,11 +93,6 @@ export default function LandingPage() {
 
           await registerFcmToken();
           router.replace('/(page)/feed');
-
-          // setName('이유진');
-          // setPosition('FE');
-          // setCardinal(4);
-          // router.push('/signup/terms');
         }
       } else {
         switch (result.code) {

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -76,11 +76,11 @@ export default function LandingPage() {
           // 최초 로그인: 약관 페이지로 이동
           router.push('/signup/terms');
         } else if (result.code === 1003) {
-          // 일반 로그인: 바로 피드로 이동
+          // 일반 로그인: 바로 링크로 이동
           await saveAccessToken(serverToken);
           await saveRefreshToken(refreshToken);
           await registerFcmToken();
-          router.replace('/(page)/feed');
+          router.replace('/(page)/leenk');
         }
       } else {
         switch (result.code) {

--- a/components/Modal/PopupModal.tsx
+++ b/components/Modal/PopupModal.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/theme/globalStyles';
 import colors from '@/theme/color';
 import CustomButton from '../common/Button/CustomButton';
+import Loading from '../common/Loading';
 
 /* 
 🦄스타일링 설명
@@ -30,6 +31,7 @@ interface PopupModalProps {
   isCancel?: boolean;
   leftBtnText?: string;
   rightBtnText: string;
+  isLoading?: boolean;
 }
 
 export default function PopupModal({
@@ -42,7 +44,9 @@ export default function PopupModal({
   isWarning = false,
   leftBtnText = '취소',
   rightBtnText,
+  isLoading = false,
 }: PopupModalProps) {
+  if (isLoading) return <Loading />;
   return (
     <Modal
       animationType="none"

--- a/components/Modal/ReportModal.tsx
+++ b/components/Modal/ReportModal.tsx
@@ -15,6 +15,7 @@ import { Textarea } from '@/components';
 import { useModalStore } from '@/stores/modalStore';
 import { useToastStore } from '@/stores/toastStore';
 import { reportFeed } from '@/api/feed/feed.api';
+import { reportLeenk } from '@/api/leenk/leenk.post.api';
 
 interface ReportModalProps {
   type: 'feed' | 'leenk';
@@ -44,7 +45,7 @@ export default function ReportModal({
       if (type === 'feed') {
         await reportFeed(targetId, report);
       } else {
-        // TODO: 링크 신고 API
+        await reportLeenk(targetId, report);
       }
       showToast(
         `해당 ${type === 'feed' ? '피드' : '링크'}를 신고했어`,

--- a/components/common/Header/Header.tsx
+++ b/components/common/Header/Header.tsx
@@ -19,6 +19,8 @@ interface HeaderProps extends ViewProps {
   signUpBackPress?: () => void;
   kebabPress?: () => void;
   kebabColor?: 'white' | 'black';
+  rightDisabled?: boolean;
+  leenkId?: number;
 }
 
 export default function Header({
@@ -29,6 +31,8 @@ export default function Header({
   RightSection = 'NONE',
   kebabPress,
   kebabColor,
+  rightDisabled = false,
+  leenkId = 0,
   ...props
 }: HeaderProps) {
   return (
@@ -54,7 +58,13 @@ export default function Header({
         {RightSection === 'KEBAB' && (
           <KebabButton handleKebab={kebabPress} color={kebabColor} />
         )}
-        {RightSection === 'KICK' && <UserKickButton handleKick={kebabPress} />}
+        {RightSection === 'KICK' && (
+          <UserKickButton
+            leenkId={leenkId}
+            handleKick={kebabPress}
+            disabled={rightDisabled}
+          />
+        )}
         {RightSection === 'NONE' && <None />}
       </Side>
     </Container>

--- a/components/common/Header/Header.tsx
+++ b/components/common/Header/Header.tsx
@@ -62,7 +62,7 @@ export default function Header({
           <UserKickButton
             leenkId={leenkId}
             handleKick={kebabPress}
-            disabled={rightDisabled}
+            disabled={rightDisabled || !leenkId}
           />
         )}
         {RightSection === 'NONE' && <None />}

--- a/components/common/Header/UserKickButton.tsx
+++ b/components/common/Header/UserKickButton.tsx
@@ -10,15 +10,26 @@ import {
 import styled from 'styled-components/native';
 import { useParticipantStore } from '@/stores/participantStore';
 import PopupModal from '@/components/Modal/PopupModal';
+import { kickLeenkParticipants } from '@/api/leenk/leenk.del.api';
+import { useToastStore } from '@/stores/toastStore';
+import Loading from '../Loading';
 
 interface Props {
+  leenkId: number;
   handleKick?: () => void;
+  disabled?: boolean;
 }
 
-export default function UserKickButton({ handleKick }: Props) {
+export default function UserKickButton({
+  leenkId,
+  handleKick,
+  disabled,
+}: Props) {
   const { selectedUsers, isSelectionMode, resetSelection } =
     useParticipantStore();
+  const { showToast } = useToastStore();
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
 
   const isZero = selectedUsers.length === 0;
 
@@ -26,13 +37,27 @@ export default function UserKickButton({ handleKick }: Props) {
     if (!isZero) {
       setIsModalOpen(true);
     }
-
     handleKick?.();
   };
 
-  const handleKickAPI = () => {
-    resetSelection();
-    setIsModalOpen(false);
+  const handleKickAPI = async () => {
+    try {
+      setLoading(true);
+
+      // 선택된 참여자들을 순회하며 내보내기 API 호출
+      for (const user of selectedUsers) {
+        await kickLeenkParticipants(leenkId, user.participant.userId);
+      }
+
+      showToast('참여자를 내보냈어.', 'success');
+    } catch (e) {
+      console.error('참여자 내보내기 실패:', e);
+      showToast('내보내기에 실패했어.', 'error');
+    } finally {
+      resetSelection();
+      setIsModalOpen(false);
+      setLoading(false);
+    }
   };
 
   const handleExit = () => {
@@ -40,15 +65,17 @@ export default function UserKickButton({ handleKick }: Props) {
     resetSelection();
   };
 
+  if (loading) return <Loading />;
+
   return (
     <>
-      <Container onPress={handlePress}>
+      <Container onPress={handlePress} disabled={disabled}>
         {(isSelectionMode || selectedUsers.length > 0) && (
           <CountBadge $isZero={isZero}>
             <CountText>{selectedUsers.length}</CountText>
           </CountBadge>
         )}
-        <ButtonText>내보내기</ButtonText>
+        <ButtonText disabled={disabled}>내보내기</ButtonText>
       </Container>
 
       <PopupModal
@@ -69,13 +96,14 @@ const Container = styled.Pressable`
   flex-direction: row;
   align-items: center;
   padding: ${8 * height}px ${12 * width}px;
-  background-color: ${colors.divider[2]};
+  background-color: ${({ disabled }) =>
+    disabled ? colors.gray[100] : colors.divider[2]};
   border-radius: 100px;
 `;
 
 const ButtonText = styled.Text`
   font-size: ${fontSize.sm}px;
-  color: ${colors.text[1]};
+  color: ${({ disabled }) => (disabled ? colors.gray[400] : colors.text[1])};
   font-family: ${fonts.Bold};
   line-height: ${lineHeight.s}px;
 `;

--- a/components/common/Header/UserKickButton.tsx
+++ b/components/common/Header/UserKickButton.tsx
@@ -25,8 +25,12 @@ export default function UserKickButton({
   handleKick,
   disabled,
 }: Props) {
-  const { selectedUsers, isSelectionMode, resetSelection } =
-    useParticipantStore();
+  const {
+    selectedUsers,
+    isSelectionMode,
+    resetSelection,
+    removeParticipantsByIds,
+  } = useParticipantStore();
   const { showToast } = useToastStore();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -44,10 +48,16 @@ export default function UserKickButton({
     try {
       setLoading(true);
 
-      // 선택된 참여자들을 순회하며 내보내기 API 호출
-      for (const user of selectedUsers) {
-        await kickLeenkParticipants(leenkId, user.participant.userId);
-      }
+      // resetSelection 전에 userIds 확보
+      const kickedIds = selectedUsers.map((u) => u.participant.userId);
+
+      // 여러 명 병렬 처리
+      await Promise.all(
+        kickedIds.map((id) => kickLeenkParticipants(leenkId, id)),
+      );
+
+      // 화면 즉시 반영 (옵티미스틱)
+      removeParticipantsByIds(kickedIds);
 
       showToast('참여자를 내보냈어.', 'success');
     } catch (e) {
@@ -59,7 +69,6 @@ export default function UserKickButton({
       setLoading(false);
     }
   };
-
   const handleExit = () => {
     setIsModalOpen(false);
     resetSelection();

--- a/components/common/Header/UserKickButton.tsx
+++ b/components/common/Header/UserKickButton.tsx
@@ -51,15 +51,26 @@ export default function UserKickButton({
       // resetSelection 전에 userIds 확보
       const kickedIds = selectedUsers.map((u) => u.participant.userId);
 
-      // 여러 명 병렬 처리
-      await Promise.all(
+      // 여러 명 병렬 처리(부분 성공 허용)
+      const results = await Promise.allSettled(
         kickedIds.map((id) => kickLeenkParticipants(leenkId, id)),
       );
+      const successIds: number[] = [];
+      const failed = results.filter((r, idx) => {
+        const ok = r.status === 'fulfilled';
+        if (ok) successIds.push(kickedIds[idx]);
+        return r.status === 'rejected';
+      });
 
-      // 화면 즉시 반영 (옵티미스틱)
-      removeParticipantsByIds(kickedIds);
+      if (successIds.length) {
+        removeParticipantsByIds(successIds);
+      }
 
-      showToast('참여자를 내보냈어.', 'success');
+      if (failed.length) {
+        showToast(`일부 내보내기 실패(${failed.length}명)`, 'error');
+      } else {
+        showToast('참여자를 내보냈어.', 'success');
+      }
     } catch (e) {
       console.error('참여자 내보내기 실패:', e);
       showToast('내보내기에 실패했어.', 'error');

--- a/components/common/TabMenu.tsx
+++ b/components/common/TabMenu.tsx
@@ -22,8 +22,8 @@ export default function TabMenu({
         ]
       : [
           { label: '전체', value: 'all' },
-          { label: '모집중', value: 'recruiting' },
-          { label: '모집완료', value: 'completed' },
+          { label: '모집중', value: 'open' },
+          { label: '모집완료', value: 'close' },
         ];
 
   return (

--- a/components/common/Textarea.tsx
+++ b/components/common/Textarea.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { TextInputProps } from 'react-native';
+import { Platform, TextInputProps } from 'react-native';
 import styled from 'styled-components/native';
 import { fontSize, radius, height, width, fonts } from '@/theme/globalStyles';
 import colors from '@/theme/color';
@@ -14,6 +14,7 @@ interface TextareaProps extends TextInputProps {
   maxHeight?: number;
   isRequired?: boolean;
   fontSizeKey?: keyof typeof fontSize;
+  accessoryID?: string;
 }
 
 export default function Textarea({
@@ -28,6 +29,7 @@ export default function Textarea({
   isRequired = false,
   onChangeText,
   fontSizeKey = 'md',
+  accessoryID,
   ...props
 }: TextareaProps) {
   const [focused, setFocused] = useState(false);
@@ -62,6 +64,9 @@ export default function Textarea({
             setFocused(false);
             props.onBlur?.(e);
           }}
+          {...(Platform.OS === 'ios'
+            ? { inputAccessoryViewID: accessoryID }
+            : {})}
         />
         <CharCount
           isDark={isDark}

--- a/components/common/Textarea.tsx
+++ b/components/common/Textarea.tsx
@@ -106,7 +106,7 @@ const StyledTextarea = styled.TextInput<{
   max-height: ${({ maxHeight }) =>
     maxHeight ? `${maxHeight * height}px` : `${85 * height}px`};
   font-size: ${({ fontSizeKey }) => fontSize[fontSizeKey]}px;
-  font-family: ${fonts.Bold};
+  font-family: ${fonts.Regular};
   color: ${({ isDark }) => (isDark ? colors.white : colors.black)};
   text-align-vertical: top;
 `;

--- a/components/leenk/LeenkDetailBottomButton.tsx
+++ b/components/leenk/LeenkDetailBottomButton.tsx
@@ -37,6 +37,11 @@ export default function LeenkBottomButtonSection({
       : false;
   }, [leenkDetail?.startTime]);
 
+  // 정원 계산
+  const isFull = useMemo(() => {
+    return leenkDetail.currentParticipants >= leenkDetail.maxParticipants;
+  }, [leenkDetail.currentParticipants, leenkDetail.maxParticipants]);
+
   const renderButtons = () => {
     // 1. 작성자일 경우
     if (isAuthor) {
@@ -115,7 +120,9 @@ export default function LeenkBottomButtonSection({
     if (!isAuthor) {
       if (!leenkDetail.isParticipated) {
         const isJoinDisabled =
-          leenkDetail.status === 'CLOSED' || leenkDetail.status === 'FINISHED';
+          isFull ||
+          leenkDetail.status === 'CLOSED' ||
+          leenkDetail.status === 'FINISHED';
 
         return (
           <CustomButton

--- a/components/leenk/LeenkDetailBottomButton.tsx
+++ b/components/leenk/LeenkDetailBottomButton.tsx
@@ -32,7 +32,6 @@ export default function LeenkBottomButtonSection({
 }: Props) {
   const router = useRouter();
 
-  //TODO: 링크 종료 시간 비교해서 종료할래 버튼에 onClose or onEarlyClose 넣어주기
   return (
     <ButtonContainer $insetBottom={insetBottom}>
       {isLeenkEnd && (isAuthor || isParticipating) ? (

--- a/components/leenk/LeenkDetailBottomButton.tsx
+++ b/components/leenk/LeenkDetailBottomButton.tsx
@@ -17,6 +17,9 @@ interface Props {
   onParticipants: () => void;
 }
 
+import dayjs from 'dayjs';
+import { useMemo } from 'react';
+
 export default function LeenkBottomButtonSection({
   isAuthor,
   leenkDetail,
@@ -27,6 +30,13 @@ export default function LeenkBottomButtonSection({
   onJoin,
   onParticipants,
 }: Props) {
+  // 링크 시작 시간 계산
+  const isBeforeStart = useMemo(() => {
+    return leenkDetail?.startTime
+      ? dayjs().isBefore(dayjs(leenkDetail.startTime))
+      : false;
+  }, [leenkDetail?.startTime]);
+
   const renderButtons = () => {
     // 1. 작성자일 경우
     if (isAuthor) {
@@ -55,6 +65,7 @@ export default function LeenkBottomButtonSection({
           </>
         );
       }
+
       if (leenkDetail.status === 'CLOSED') {
         // 1-2 CLOSED
         return (
@@ -74,12 +85,14 @@ export default function LeenkBottomButtonSection({
               rounded="md"
               size="lg"
               style={{ flex: 1, marginLeft: 10 * width }}
+              disabled={isBeforeStart}
             >
               링크 종료할래
             </CustomButton>
           </>
         );
       }
+
       if (leenkDetail.status === 'FINISHED') {
         // 1-3 FINISHED
         return (
@@ -100,7 +113,6 @@ export default function LeenkBottomButtonSection({
 
     // 2. 참여자(작성자 아님)일 경우
     if (!isAuthor) {
-      // 참여하지 않은 경우
       if (!leenkDetail.isParticipated) {
         const isJoinDisabled =
           leenkDetail.status === 'CLOSED' || leenkDetail.status === 'FINISHED';
@@ -119,7 +131,6 @@ export default function LeenkBottomButtonSection({
         );
       }
 
-      // "참여 중" 사용자
       if (leenkDetail.status === 'RECRUITING') {
         return (
           <>
@@ -185,25 +196,9 @@ export default function LeenkBottomButtonSection({
           </CustomButton>
         );
       }
-
-      if (leenkDetail.status === 'FINISHED') {
-        return (
-          <CustomButton
-            variant="primary"
-            onPress={() => {
-              router.push('/(post)/feed');
-            }}
-            rounded="md"
-            size="lg"
-            fullWidth
-          >
-            후기 쓰러가자
-          </CustomButton>
-        );
-      }
     }
 
-    // 예외 상황(알 수 없는 상태) 대비: 참가 버튼만 노출
+    // Fallback
     return (
       <CustomButton
         variant="primary"

--- a/components/leenk/LeenkDetailBottomButton.tsx
+++ b/components/leenk/LeenkDetailBottomButton.tsx
@@ -1,5 +1,3 @@
-// components/leenk/LeenkBottomButtonSection.tsx
-
 import { width, height } from '@/theme/globalStyles';
 import styled from 'styled-components/native';
 import colors from '@/theme/color';
@@ -49,7 +47,7 @@ export default function LeenkBottomButtonSection({
           <CustomButton
             variant="secondary"
             textColor="text[2]"
-            onPress={() => router.push('/leenk/participants-list')}
+            onPress={onParticipants}
             rounded="md"
             size="lg"
           >

--- a/components/leenk/LeenkDetailBottomButton.tsx
+++ b/components/leenk/LeenkDetailBottomButton.tsx
@@ -2,16 +2,16 @@ import { width, height } from '@/theme/globalStyles';
 import styled from 'styled-components/native';
 import colors from '@/theme/color';
 import { CustomButton } from '@/components';
-import { useRouter } from 'expo-router';
 import { CONTAINER_PADDING } from '@/constants';
+import { router } from 'expo-router';
 
 interface Props {
   isAuthor: boolean;
   isParticipating: boolean;
-  isLeenkEnd: boolean;
   insetBottom: number;
+  leenkStatus: 'RECRUITING' | 'CLOSED' | 'FINISHED' | string;
   onLeave: () => void;
-  onEalryClose: () => void;
+  onFinish: () => void;
   onClose: () => void;
   onJoin: () => void;
   onParticipants: () => void;
@@ -20,81 +20,161 @@ interface Props {
 export default function LeenkBottomButtonSection({
   isAuthor,
   isParticipating,
-  isLeenkEnd,
   insetBottom,
+  leenkStatus,
   onLeave,
-  onEalryClose,
+  onFinish,
   onClose,
   onJoin,
   onParticipants,
 }: Props) {
-  const router = useRouter();
+  const renderButtons = () => {
+    // 1. 작성자일 경우
+    if (isAuthor) {
+      if (leenkStatus === 'RECRUITING') {
+        // 1-1 RECRUITING
+        return (
+          <>
+            <CustomButton
+              variant="secondary"
+              textColor="text[2]"
+              onPress={onParticipants}
+              rounded="md"
+              size="lg"
+            >
+              모임원 관리
+            </CustomButton>
+            <CustomButton
+              variant="primary"
+              onPress={onClose}
+              rounded="md"
+              size="lg"
+              style={{ flex: 1, marginLeft: 10 * width }}
+            >
+              모집 종료할래
+            </CustomButton>
+          </>
+        );
+      }
+      if (leenkStatus === 'CLOSED') {
+        // 1-2 CLOSED
+        return (
+          <>
+            <CustomButton
+              variant="secondary"
+              textColor="text[2]"
+              onPress={onParticipants}
+              rounded="md"
+              size="lg"
+            >
+              모임원 관리
+            </CustomButton>
+            <CustomButton
+              variant="primary"
+              onPress={onFinish}
+              rounded="md"
+              size="lg"
+              style={{ flex: 1, marginLeft: 10 * width }}
+            >
+              링크 종료할래
+            </CustomButton>
+          </>
+        );
+      }
+      if (leenkStatus === 'FINISHED') {
+        // 1-3 FINISHED
+        return (
+          <CustomButton
+            variant="primary"
+            onPress={() => {
+              router.push('/(post)/feed');
+            }}
+            rounded="md"
+            size="lg"
+            fullWidth
+          >
+            후기 쓰러가자
+          </CustomButton>
+        );
+      }
+    }
+
+    // 2. 참여자(작성자 아님)일 경우
+    if (!isAuthor) {
+      if (leenkStatus === 'RECRUITING') {
+        // 2-1 RECRUITING
+        return (
+          <CustomButton
+            variant="primary"
+            onPress={onJoin}
+            rounded="md"
+            size="lg"
+            fullWidth
+          >
+            참여할래
+          </CustomButton>
+        );
+      }
+      if (leenkStatus === 'CLOSED') {
+        // 2-2 CLOSED
+        return (
+          <>
+            <CustomButton
+              variant="secondary"
+              textColor="text[2]"
+              onPress={onParticipants}
+              rounded="md"
+              size="lg"
+            >
+              모임원 보기
+            </CustomButton>
+            <CustomButton
+              variant="primary"
+              onPress={onLeave}
+              rounded="md"
+              size="lg"
+              style={{ flex: 1, marginLeft: 10 * width }}
+            >
+              링크 나갈래
+            </CustomButton>
+          </>
+        );
+      }
+      if (leenkStatus === 'FINISHED') {
+        // 2-3 FINISHED
+        return (
+          <CustomButton
+            variant="primary"
+            onPress={() => {
+              router.push('/(post)/feed');
+            }}
+            rounded="md"
+            size="lg"
+            fullWidth
+          >
+            후기 쓰러가자
+          </CustomButton>
+        );
+      }
+    }
+
+    // 예외 상황(알 수 없는 상태) 대비: 참가 버튼만 노출
+    return (
+      <CustomButton
+        variant="primary"
+        onPress={onJoin}
+        rounded="md"
+        size="lg"
+        fullWidth
+      >
+        참여할래
+      </CustomButton>
+    );
+  };
 
   return (
     <ButtonContainer $insetBottom={insetBottom}>
-      {isLeenkEnd && (isAuthor || isParticipating) ? (
-        <CustomButton
-          variant="primary"
-          onPress={() => router.push('/(post)/feed')}
-          rounded="md"
-          size="lg"
-          fullWidth
-        >
-          후기 쓰러갈래
-        </CustomButton>
-      ) : isAuthor ? (
-        <>
-          <CustomButton
-            variant="secondary"
-            textColor="text[2]"
-            onPress={onParticipants}
-            rounded="md"
-            size="lg"
-          >
-            모임원 관리
-          </CustomButton>
-          <CustomButton
-            variant="primary"
-            onPress={onClose}
-            rounded="md"
-            size="lg"
-            style={{ flex: 1, marginLeft: 10 * width }}
-          >
-            모집 종료할래
-          </CustomButton>
-        </>
-      ) : isParticipating ? (
-        <>
-          <CustomButton
-            variant="secondary"
-            textColor="text[2]"
-            onPress={onParticipants}
-            rounded="md"
-            size="lg"
-          >
-            모임원 보기
-          </CustomButton>
-          <CustomButton
-            variant="primary"
-            onPress={onLeave}
-            rounded="md"
-            size="lg"
-            style={{ flex: 1, marginLeft: 10 * width }}
-          >
-            링크 나갈래
-          </CustomButton>
-        </>
-      ) : (
-        <CustomButton
-          variant="primary"
-          onPress={onJoin}
-          rounded="md"
-          size="lg"
-          fullWidth
-        >
-          참여할래
-        </CustomButton>
-      )}
+      {renderButtons()}
     </ButtonContainer>
   );
 }

--- a/components/leenk/LeenkDetailBottomButton.tsx
+++ b/components/leenk/LeenkDetailBottomButton.tsx
@@ -4,12 +4,12 @@ import colors from '@/theme/color';
 import { CustomButton } from '@/components';
 import { CONTAINER_PADDING } from '@/constants';
 import { router } from 'expo-router';
+import { LeenkDetail } from '@/types/leenk';
 
 interface Props {
   isAuthor: boolean;
-  isParticipating: boolean;
   insetBottom: number;
-  leenkStatus: 'RECRUITING' | 'CLOSED' | 'FINISHED' | string;
+  leenkDetail: LeenkDetail;
   onLeave: () => void;
   onFinish: () => void;
   onClose: () => void;
@@ -19,9 +19,8 @@ interface Props {
 
 export default function LeenkBottomButtonSection({
   isAuthor,
-  isParticipating,
+  leenkDetail,
   insetBottom,
-  leenkStatus,
   onLeave,
   onFinish,
   onClose,
@@ -31,7 +30,7 @@ export default function LeenkBottomButtonSection({
   const renderButtons = () => {
     // 1. 작성자일 경우
     if (isAuthor) {
-      if (leenkStatus === 'RECRUITING') {
+      if (leenkDetail.status === 'RECRUITING') {
         // 1-1 RECRUITING
         return (
           <>
@@ -56,7 +55,7 @@ export default function LeenkBottomButtonSection({
           </>
         );
       }
-      if (leenkStatus === 'CLOSED') {
+      if (leenkDetail.status === 'CLOSED') {
         // 1-2 CLOSED
         return (
           <>
@@ -81,7 +80,7 @@ export default function LeenkBottomButtonSection({
           </>
         );
       }
-      if (leenkStatus === 'FINISHED') {
+      if (leenkDetail.status === 'FINISHED') {
         // 1-3 FINISHED
         return (
           <CustomButton
@@ -101,8 +100,11 @@ export default function LeenkBottomButtonSection({
 
     // 2. 참여자(작성자 아님)일 경우
     if (!isAuthor) {
-      if (leenkStatus === 'RECRUITING') {
-        // 2-1 RECRUITING
+      // 참여하지 않은 경우
+      if (!leenkDetail.isParticipated) {
+        const isJoinDisabled =
+          leenkDetail.status === 'CLOSED' || leenkDetail.status === 'FINISHED';
+
         return (
           <CustomButton
             variant="primary"
@@ -110,13 +112,15 @@ export default function LeenkBottomButtonSection({
             rounded="md"
             size="lg"
             fullWidth
+            disabled={isJoinDisabled}
           >
             참여할래
           </CustomButton>
         );
       }
-      if (leenkStatus === 'CLOSED') {
-        // 2-2 CLOSED
+
+      // "참여 중" 사용자
+      if (leenkDetail.status === 'RECRUITING') {
         return (
           <>
             <CustomButton
@@ -140,8 +144,49 @@ export default function LeenkBottomButtonSection({
           </>
         );
       }
-      if (leenkStatus === 'FINISHED') {
-        // 2-3 FINISHED
+
+      if (leenkDetail.status === 'CLOSED') {
+        return (
+          <>
+            <CustomButton
+              variant="secondary"
+              textColor="text[2]"
+              onPress={onParticipants}
+              rounded="md"
+              size="lg"
+            >
+              모임원 보기
+            </CustomButton>
+            <CustomButton
+              variant="primary"
+              onPress={onLeave}
+              rounded="md"
+              size="lg"
+              style={{ flex: 1, marginLeft: 10 * width }}
+            >
+              링크 나갈래
+            </CustomButton>
+          </>
+        );
+      }
+
+      if (leenkDetail.status === 'FINISHED') {
+        return (
+          <CustomButton
+            variant="primary"
+            onPress={() => {
+              router.push('/(post)/feed');
+            }}
+            rounded="md"
+            size="lg"
+            fullWidth
+          >
+            후기 쓰러가자
+          </CustomButton>
+        );
+      }
+
+      if (leenkDetail.status === 'FINISHED') {
         return (
           <CustomButton
             variant="primary"

--- a/components/leenk/LeenkDetailContent.tsx
+++ b/components/leenk/LeenkDetailContent.tsx
@@ -16,7 +16,7 @@ import {
 import colors from '@/theme/color';
 import { Pressable } from 'react-native';
 import styled from 'styled-components/native';
-import { formatRelativeTime } from '@/utils/format-date';
+import { formatMonthDayHour, formatRelativeTime } from '@/utils/format-date';
 import { TimeText } from '@/components/leenk/LeenkListItem';
 import { LeenkDetail } from '@/types/leenk';
 
@@ -68,7 +68,7 @@ export default function LeenkContentSection({
 
       <RowWrapper>
         <ClockIcon width={width * 16} />
-        <TimeText>{data.startTime}</TimeText>
+        <TimeText>{formatMonthDayHour(data.startTime)}</TimeText>
       </RowWrapper>
 
       <ContentWrapper $insetBottom={insetBottom}>

--- a/components/leenk/LeenkDetailContent.tsx
+++ b/components/leenk/LeenkDetailContent.tsx
@@ -18,32 +18,17 @@ import { Pressable } from 'react-native';
 import styled from 'styled-components/native';
 import { formatRelativeTime } from '@/utils/format-date';
 import { TimeText } from '@/components/leenk/LeenkListItem';
+import { LeenkDetail } from '@/types/leenk';
 
 interface Props {
-  title: string;
-  place: string;
-  content: string;
-  date: string;
-  name: string;
-  createdAt: string;
-  profileImageUri: string | null;
-  participantCount: number;
-  allParticipants: number;
+  data: LeenkDetail;
   insetBottom: number;
   onShare: () => void;
   onParticipants: () => void;
 }
 
 export default function LeenkContentSection({
-  title,
-  place,
-  content,
-  date,
-  name,
-  createdAt,
-  profileImageUri,
-  participantCount,
-  allParticipants,
+  data,
   insetBottom,
   onShare,
   onParticipants,
@@ -51,16 +36,16 @@ export default function LeenkContentSection({
   return (
     <Container showsVerticalScrollIndicator={false}>
       <TitleRow>
-        <Title>{title}</Title>
+        <Title>{data.title}</Title>
         <ShareButton onPress={onShare}>
           <ShareIcon width={24 * width} />
         </ShareButton>
       </TitleRow>
 
       <RowWrapper>
-        <ProfileImageWithFallback uri={profileImageUri} size={24} />
+        <ProfileImageWithFallback uri={data.author.profileImage} size={24} />
         <TimeText style={{ marginLeft: width * 8 }}>
-          {name}・{formatRelativeTime(createdAt)}
+          {data.author.name}・{formatRelativeTime(data.createdAt)}
         </TimeText>
       </RowWrapper>
 
@@ -69,7 +54,7 @@ export default function LeenkContentSection({
       <RowWrapper>
         <PeopleIcon width={width * 16} />
         <TimeText>
-          {participantCount}/{allParticipants}명
+          {data.currentParticipants}/{data.maxParticipants}명
         </TimeText>
         <Pressable onPress={onParticipants}>
           <RightArrowIcon width={width * 16} />
@@ -78,15 +63,16 @@ export default function LeenkContentSection({
 
       <RowWrapper>
         <LocateIcon width={width * 16} />
-        <TimeText>{place}</TimeText>
+        <TimeText>{data.placeName}</TimeText>
       </RowWrapper>
 
       <RowWrapper>
         <ClockIcon width={width * 16} />
-        <TimeText>{date}</TimeText>
+        <TimeText>{data.startTime}</TimeText>
       </RowWrapper>
+
       <ContentWrapper $insetBottom={insetBottom}>
-        <ContentText>{content}</ContentText>
+        <ContentText>{data.content}</ContentText>
       </ContentWrapper>
     </Container>
   );

--- a/components/leenk/LeenkDetailContent.tsx
+++ b/components/leenk/LeenkDetailContent.tsx
@@ -33,6 +33,8 @@ export default function LeenkContentSection({
   onShare,
   onParticipants,
 }: Props) {
+  console.log('시간', data.startTime);
+  console.log('포맷 시간', formatMonthDayHour(data.startTime));
   return (
     <Container showsVerticalScrollIndicator={false}>
       <TitleRow>

--- a/components/leenk/LeenkDetailModals.tsx
+++ b/components/leenk/LeenkDetailModals.tsx
@@ -7,7 +7,7 @@ type ModalType =
   | 'deleteConfirm'
   | 'leenkLeave'
   | 'leenkClose'
-  | 'leenkEarlyClose'
+  | 'leenkFinish'
   | 'leenkReport'
   | undefined;
 
@@ -19,7 +19,8 @@ interface Props {
   // actions
   onConfirmDelete: () => Promise<void> | void;
   onConfirmLeave: () => Promise<void> | void;
-  onConfirmClose: () => void;
+  onConfirmClose: () => Promise<void> | void;
+  onConfirmFinish: () => Promise<void> | void;
 }
 
 function LeenkDetailModals({
@@ -29,6 +30,7 @@ function LeenkDetailModals({
   onConfirmDelete,
   onConfirmLeave,
   onConfirmClose,
+  onConfirmFinish,
 }: Props) {
   const leaveSubText = useMemo(
     () =>
@@ -81,16 +83,16 @@ function LeenkDetailModals({
           rightBtnText="종료할래"
         />
       );
-    case 'leenkEarlyClose':
+    case 'leenkFinish':
       return (
         <PopupModal
           isOpen
-          onRightBtn={onConfirmClose}
+          onRightBtn={onConfirmFinish}
           onLeftBtn={onClose}
-          mainText={`링크 시간이 아직 남았어! \n일찍 끝낼거야?`}
+          mainText={`링크를 끝낼거야?`}
           isCancel
           leftBtnText="취소"
-          rightBtnText="삭제할래"
+          rightBtnText="종료할래"
         />
       );
     case 'leenkReport':

--- a/components/leenk/LeenkDetailModals.tsx
+++ b/components/leenk/LeenkDetailModals.tsx
@@ -1,0 +1,103 @@
+import React, { useMemo } from 'react';
+import ReportModal from '@/components/Modal/ReportModal';
+import PopupModal from '@/components/Modal/PopupModal';
+
+type ModalType =
+  | 'menu'
+  | 'deleteConfirm'
+  | 'leenkLeave'
+  | 'leenkClose'
+  | 'leenkEarlyClose'
+  | 'leenkReport'
+  | undefined;
+
+interface Props {
+  modalType: ModalType;
+  title: string;
+  onClose: () => void;
+
+  // actions
+  onConfirmDelete: () => Promise<void> | void;
+  onConfirmLeave: () => Promise<void> | void;
+  onConfirmClose: () => void;
+}
+
+function LeenkDetailModals({
+  modalType,
+  title,
+  onClose,
+  onConfirmDelete,
+  onConfirmLeave,
+  onConfirmClose,
+}: Props) {
+  const leaveSubText = useMemo(
+    () =>
+      title.length > 10
+        ? `${title.slice(0, 10)}...에서 나가지게 돼.`
+        : `${title}에서 나가지게 돼.`,
+    [title],
+  );
+
+  switch (modalType) {
+    case 'deleteConfirm':
+      return (
+        <PopupModal
+          isOpen
+          onRightBtn={onConfirmDelete}
+          onLeftBtn={onClose}
+          isWarning
+          mainText="모집글을 삭제할거야?"
+          subText="삭제하면 복구할 수 없어."
+          isCancel
+          leftBtnText="취소"
+          rightBtnText="삭제할래"
+        />
+      );
+    case 'leenkLeave':
+      return (
+        <PopupModal
+          isOpen
+          onRightBtn={onConfirmLeave}
+          onLeftBtn={onClose}
+          isWarning
+          mainText="정말 떠날거야?"
+          subText={leaveSubText}
+          isCancel
+          leftBtnText="취소"
+          rightBtnText="나갈래"
+        />
+      );
+    case 'leenkClose':
+      return (
+        <PopupModal
+          isOpen
+          onRightBtn={onConfirmClose}
+          onLeftBtn={onClose}
+          isWarning
+          mainText={`아직 모임 시간이 아니야! \n모집을 종료할까?`}
+          subText="종료하면 다시 모집할 수 없어."
+          isCancel
+          leftBtnText="취소"
+          rightBtnText="종료할래"
+        />
+      );
+    case 'leenkEarlyClose':
+      return (
+        <PopupModal
+          isOpen
+          onRightBtn={onConfirmClose}
+          onLeftBtn={onClose}
+          mainText={`링크 시간이 아직 남았어! \n일찍 끝낼거야?`}
+          isCancel
+          leftBtnText="취소"
+          rightBtnText="삭제할래"
+        />
+      );
+    case 'leenkReport':
+      return <ReportModal type="leenk" />;
+    default:
+      return null;
+  }
+}
+
+export default React.memo(LeenkDetailModals);

--- a/components/leenk/LeenkDetailModals.tsx
+++ b/components/leenk/LeenkDetailModals.tsx
@@ -1,6 +1,12 @@
 import React, { useMemo } from 'react';
 import ReportModal from '@/components/Modal/ReportModal';
 import PopupModal from '@/components/Modal/PopupModal';
+import BottomSheetModal from '../Modal/BottomSheetModal';
+import CustomButton from '../common/Button/CustomButton';
+import { router } from 'expo-router';
+import { height } from '@/theme/globalStyles';
+import { SubText, TitleText } from '@/components/OnBoarding';
+import { ReviewIcon } from '@/assets';
 
 type ModalType =
   | 'menu'
@@ -9,6 +15,7 @@ type ModalType =
   | 'leenkClose'
   | 'leenkFinish'
   | 'leenkReport'
+  | 'bottomSheet'
   | undefined;
 
 interface Props {
@@ -97,6 +104,42 @@ function LeenkDetailModals({
       );
     case 'leenkReport':
       return <ReportModal type="leenk" />;
+
+    case 'bottomSheet':
+      return (
+        <BottomSheetModal visible>
+          <TitleText>{'링크가 마무리 됐어 :)'}</TitleText>
+          <SubText>수고했어! 후기 남기러 가볼까?</SubText>
+          <ReviewIcon
+            style={{
+              alignSelf: 'center',
+              marginTop: 16 * height,
+              marginBottom: 40 * height,
+            }}
+            height={200}
+            width={200}
+          />
+          <CustomButton
+            fullWidth
+            onPress={() => {
+              onClose();
+              router.push('/feed');
+            }}
+          >
+            후기 쓰러갈래
+          </CustomButton>
+          <CustomButton
+            variant="text"
+            textColor="text[2]"
+            fullWidth
+            onPress={() => {
+              onClose();
+            }}
+          >
+            나중에 할래
+          </CustomButton>
+        </BottomSheetModal>
+      );
     default:
       return null;
   }

--- a/components/leenk/LeenkImagePicker.tsx
+++ b/components/leenk/LeenkImagePicker.tsx
@@ -1,5 +1,4 @@
-import { useState } from 'react';
-import { Pressable } from 'react-native';
+import { useState, useEffect, useMemo } from 'react';
 import styled from 'styled-components/native';
 import {
   GalleryIcon,
@@ -20,52 +19,78 @@ import {
 } from '@/theme/globalStyles';
 import { useRouter } from 'expo-router';
 import { useLeenkImageStore } from '@/stores/leenkStore';
+import { LEENK_DEFAULT_IMAGE_URLS } from '@/constants/leenkDefaultImages';
 
 export default function LeenkImagePicker() {
   const imageSize = width * 106;
   const router = useRouter();
 
-  const { leenkImage } = useLeenkImageStore();
+  const { leenkImage, setLeenkImage } = useLeenkImageStore();
+
+  // SVG 리스트(그림)와 URL 리스트(실제 전송값)를 같은 인덱스로 매핑
+  const defaultSvgs = useMemo(
+    () => [LeenkImg03, LeenkImg02, LeenkImg01, LeenkImg04, LeenkImg05],
+    [],
+  );
+  const defaultUrls = LEENK_DEFAULT_IMAGE_URLS;
+
+  // 현재 선택 상태: 0~4(기본 이미지 인덱스), 'upload'(업로드 슬롯), null(미선택)
   const [selectedIndex, setSelectedIndex] = useState<number | 'upload' | null>(
     null,
   );
 
-  const defaultImages = [
-    LeenkImg01,
-    LeenkImg02,
-    LeenkImg03,
-    LeenkImg04,
-    LeenkImg05,
-  ];
+  // store의 값으로 선택 상태 초기화/동기화
+  useEffect(() => {
+    if (!leenkImage) {
+      setSelectedIndex(null);
+      return;
+    }
+    const idx = defaultUrls.indexOf(leenkImage);
+    if (idx >= 0) {
+      // 기본 이미지 중 하나가 선택된 상태
+      setSelectedIndex(idx);
+    } else {
+      setSelectedIndex('upload');
+    }
+  }, [leenkImage, defaultUrls]);
 
   const openUpload = () => {
-    router.push({
-      pathname: '/(post)/leenk/select-image',
-    });
+    setSelectedIndex('upload');
+    router.push({ pathname: '/(post)/leenk/select-image' });
   };
+
+  // 기본 이미지 눌렀을 때: 선택 + store에 해당 S3 URL 저장
+  const handlePickDefault = (index: number) => {
+    setSelectedIndex(index);
+    setLeenkImage(defaultUrls[index]);
+  };
+
+  const isDefaultSelected = leenkImage
+    ? defaultUrls.includes(leenkImage)
+    : false;
 
   return (
     <Container>
       <ImageGrid>
-        {defaultImages.map((SvgComponent, index) => (
+        {defaultSvgs.map((SvgComponent, index) => (
           <SquareImage
             key={index}
             style={{ width: imageSize, height: imageSize }}
             $selected={selectedIndex === index}
-            onPress={() => setSelectedIndex(index)}
+            onPress={() => handlePickDefault(index)}
           >
             <SvgComponent width="100%" height="100%" />
           </SquareImage>
         ))}
+
+        {/* 업로드 슬롯 */}
         <ImageUploadButton
           style={{ width: imageSize, height: imageSize }}
-          onPress={() => {
-            setSelectedIndex('upload');
-            openUpload();
-          }}
+          onPress={openUpload}
           $selected={selectedIndex === 'upload'}
         >
-          {leenkImage ? (
+          {/* 기본 이미지가 선택된 상태라면 업로드 슬롯에는 미리보기 표시하지 않음 */}
+          {leenkImage && !isDefaultSelected ? (
             <UploadedImg source={{ uri: leenkImage }} />
           ) : (
             <>

--- a/components/leenk/LeenkListItem.tsx
+++ b/components/leenk/LeenkListItem.tsx
@@ -12,50 +12,51 @@ import {
 } from '@/theme/globalStyles';
 import { CheckerIcon, ClockIcon, PeopleIcon } from '@/assets';
 import { useRouter } from 'expo-router';
-import { LeenkDataType } from '@/constants/mockUserData';
 
-export default function LeenkListItem({
-  id,
-  title,
-  date,
-  people,
-  name,
-  leenkImageUri,
-  profileImageUri,
-}: LeenkDataType) {
+import { Leenk } from '@/types/leenk';
+
+interface Props {
+  item: Leenk;
+}
+
+export default function LeenkListItem({ item }: Props) {
   const router = useRouter();
-  console.log(id);
   return (
-    <PressableContainer onPress={() => router.push(`/leenk/${id}`)}>
+    <PressableContainer onPress={() => router.push(`/leenk/${item.leenkId}`)}>
       {({ pressed }) => (
         <StyledContainer $pressed={pressed}>
-          {leenkImageUri ? (
-            <StyledImage source={{ uri: leenkImageUri }} resizeMode="cover" />
+          {item.thumbNail ? (
+            <StyledImage source={{ uri: item.thumbNail }} resizeMode="cover" />
           ) : (
             <FallbackWrapper>
               <CheckerIcon width={width * 80} />
             </FallbackWrapper>
           )}
+
           <ContentWrapper>
             <TopSection>
               <TitleText>
-                {title.length > 12 ? `${title.slice(0, 12)}...` : title}
+                {item.title.length > 12
+                  ? `${item.title.slice(0, 12)}...`
+                  : item.title}
               </TitleText>
               <Row>
                 <ClockIcon />
-                <TimeText>{date}</TimeText>
+                <TimeText>{item.startTime}</TimeText>
                 <PeopleIcon style={{ marginLeft: width * 12 }} />
-                <TimeText style={{ marginLeft: width * 4 }}>{people}</TimeText>
+                <TimeText style={{ marginLeft: width * 4 }}>
+                  {item.currentParticipants}/{item.maxParticipants}
+                </TimeText>
               </Row>
             </TopSection>
 
             <BottomRow>
               <ProfileImageWithFallback
-                uri={profileImageUri}
+                uri={item.author.profileImage}
                 size={20}
                 isDark
               />
-              <NameText>{name}</NameText>
+              <NameText>{item.author.name}</NameText>
             </BottomRow>
           </ContentWrapper>
         </StyledContainer>

--- a/components/leenk/LeenkListItem.tsx
+++ b/components/leenk/LeenkListItem.tsx
@@ -80,6 +80,7 @@ const StyledContainer = styled.View<{ $pressed: boolean }>`
 const StyledImage = styled.Image`
   height: ${height * 80}px;
   width: ${width * 80}px;
+  border-radius: ${radius.xs}px;
 `;
 
 const FallbackWrapper = styled.View`

--- a/components/leenk/LeenkListItem.tsx
+++ b/components/leenk/LeenkListItem.tsx
@@ -14,6 +14,7 @@ import { CheckerIcon, ClockIcon, PeopleIcon } from '@/assets';
 import { useRouter } from 'expo-router';
 
 import { Leenk } from '@/types/leenk';
+import { formatMonthDayHour } from '@/utils/format-date';
 
 interface Props {
   item: Leenk;
@@ -42,7 +43,7 @@ export default function LeenkListItem({ item }: Props) {
               </TitleText>
               <Row>
                 <ClockIcon />
-                <TimeText>{item.startTime}</TimeText>
+                <TimeText>{formatMonthDayHour(item.startTime)}</TimeText>
                 <PeopleIcon style={{ marginLeft: width * 12 }} />
                 <TimeText style={{ marginLeft: width * 4 }}>
                   {item.currentParticipants}/{item.maxParticipants}

--- a/components/leenk/Stepper.tsx
+++ b/components/leenk/Stepper.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components/native';
 import colors from '@/theme/color';
 import {
@@ -11,20 +11,39 @@ import {
 } from '@/theme/globalStyles';
 import { MinusIcon, PlusIcon } from '@/assets';
 
-export default function Stepper() {
-  const [count, setCount] = useState(3);
+interface StepperProps {
+  value?: number;
+  onChange?: (next: number) => void;
+  min?: number;
+  max?: number;
+}
 
-  const handleIncrement = () => {
-    setCount((prev) => Math.min(prev + 1, 99));
+export default function Stepper({
+  value,
+  onChange,
+  min = 3,
+  max = 99,
+}: StepperProps) {
+  const [count, setCount] = useState(value ?? min);
+
+  useEffect(() => {
+    if (value !== undefined && value !== count) {
+      setCount(value);
+    }
+  }, [value]);
+
+  const update = (next: number) => {
+    const clamped = Math.min(Math.max(next, min), max);
+    setCount(clamped);
+    onChange?.(clamped);
   };
 
-  const handleDecrement = () => {
-    setCount((prev) => Math.max(prev - 1, 3));
-  };
+  const handleIncrement = () => update(count + 1);
+  const handleDecrement = () => update(count - 1);
 
   return (
     <Container>
-      <RoundBtn onPress={handleDecrement}>
+      <RoundBtn onPress={handleDecrement} disabled={count <= min}>
         <IconWrapper>
           <MinusIcon />
         </IconWrapper>
@@ -34,7 +53,7 @@ export default function Stepper() {
         <CountText>{count.toString().padStart(2, '0')}</CountText>
       </MemberNumberContainer>
 
-      <RoundBtn onPress={handleIncrement}>
+      <RoundBtn onPress={handleIncrement} disabled={count >= max}>
         <IconWrapper>
           <PlusIcon />
         </IconWrapper>
@@ -50,11 +69,12 @@ const Container = styled.View`
   margin-top: ${height * 8}px;
 `;
 
-const RoundBtn = styled.Pressable`
+const RoundBtn = styled.Pressable<{ disabled?: boolean }>`
   height: ${height * 48}px;
   width: ${width * 48}px;
   border-radius: 999px;
-  background-color: ${colors.divider[2]};
+  background-color: ${({ disabled }) =>
+    disabled ? colors.divider[1] : colors.divider[2]};
   align-items: center;
   justify-content: center;
 `;

--- a/components/leenk/UserItem.tsx
+++ b/components/leenk/UserItem.tsx
@@ -10,15 +10,15 @@ import {
 import styled from 'styled-components/native';
 import { Badge, CheckBox, ProfileImageWithFallback } from '@/components';
 import { CopyIcon } from '@/assets';
-import { LeenkDataType } from '@/constants/mockUserData';
 import { useToastStore } from '@/stores/toastStore';
 import { useParticipantStore } from '@/stores/participantStore';
+import { LeenkParticipantItem } from '@/types/leenk';
 
-export default function UserItem({ user }: { user: LeenkDataType }) {
+export default function UserItem({ user }: { user: LeenkParticipantItem }) {
   const { showToast } = useToastStore();
-  const { selectedUsers, toggleUser, isSelectionMode } = useParticipantStore();
+  const { toggleUser, isSelectionMode, isSelected } = useParticipantStore();
 
-  const checked = selectedUsers.some((u) => u.id === user.id);
+  const checked = isSelected(user.participant.userId);
 
   const handleCopyClick = async () => {
     try {
@@ -33,22 +33,22 @@ export default function UserItem({ user }: { user: LeenkDataType }) {
 
   return (
     <Wrapper>
-      <ProfileImageWithFallback uri={user.profileImageUri} />
+      <ProfileImageWithFallback uri={user.participant.profileImage} />
       <MiddleWrapper>
         <NameRow>
-          <UserName>{user.name}</UserName>
-          {user.isWrite && <Badge label="작성자" profile />}
+          <UserName>{user.participant.name}</UserName>
+          {user.isHost && <Badge label="작성자" profile />}
         </NameRow>
       </MiddleWrapper>
 
       <RightWrapper>
-        {!user.isWrite && !isSelectionMode && (
+        {!user.isHost && !isSelectionMode && (
           <KakaoWrapper onPress={handleCopyClick}>
             <KakaoIdText>{user.kakaoTalkId || 'kakao ID'}</KakaoIdText>
             <CopyIcon width={20} height={20} style={{ marginLeft: 8 }} />
           </KakaoWrapper>
         )}
-        {!user.isWrite && isSelectionMode && (
+        {!user.isHost && isSelectionMode && (
           <CheckBox onPress={() => toggleUser(user)} checked={checked} />
         )}
       </RightWrapper>

--- a/constants/leenkDefaultImages.ts
+++ b/constants/leenkDefaultImages.ts
@@ -1,0 +1,7 @@
+export const LEENK_DEFAULT_IMAGE_URLS = [
+  'https://leenk-file.s3.ap-northeast-2.amazonaws.com/template_image_1.png',
+  'https://leenk-file.s3.ap-northeast-2.amazonaws.com/template_image_2.png',
+  'https://leenk-file.s3.ap-northeast-2.amazonaws.com/template_image_3.png',
+  'https://leenk-file.s3.ap-northeast-2.amazonaws.com/template_image_4.png',
+  'https://leenk-file.s3.ap-northeast-2.amazonaws.com/template_image_5.png',
+];

--- a/hooks/usePushNotification.ts
+++ b/hooks/usePushNotification.ts
@@ -34,7 +34,7 @@ export async function requestNotificationPermission() {
   // FCM 토큰 가져오기
   const token = await messaging().getToken();
   await saveFcmToken(token);
-  console.log(token, 'fcmToken');
+  // console.log(token, 'fcmToken');
 
   // 프로필 페이지 없이 시작할 경우 해당 코드 활성화 시키기
   // const registerFcmToken = async () => {

--- a/hooks/usePushNotification.ts
+++ b/hooks/usePushNotification.ts
@@ -34,6 +34,7 @@ export async function requestNotificationPermission() {
   // FCM 토큰 가져오기
   const token = await messaging().getToken();
   await saveFcmToken(token);
+  console.log(token, 'fcmToken');
 
   // 프로필 페이지 없이 시작할 경우 해당 코드 활성화 시키기
   // const registerFcmToken = async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "react-native-animated-pagination-dots": "^0.1.73",
         "react-native-gesture-handler": "~2.24.0",
         "react-native-global-props": "^1.1.5",
+        "react-native-keyboard-aware-scroll-view": "^0.9.5",
         "react-native-linear-gradient": "^2.8.3",
         "react-native-modern-datepicker": "^1.0.0-beta.91",
         "react-native-pager-view": "^6.8.1",
@@ -13359,6 +13360,14 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-iphone-x-helper": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz",
+      "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==",
+      "peerDependencies": {
+        "react-native": ">=0.42.0"
+      }
+    },
     "node_modules/react-native-is-edge-to-edge": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz",
@@ -13366,6 +13375,18 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-keyboard-aware-scroll-view": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/react-native-keyboard-aware-scroll-view/-/react-native-keyboard-aware-scroll-view-0.9.5.tgz",
+      "integrity": "sha512-XwfRn+T/qBH9WjTWIBiJD2hPWg0yJvtaEw6RtPCa5/PYHabzBaWxYBOl0usXN/368BL1XktnZPh8C2lmTpOREA==",
+      "dependencies": {
+        "prop-types": "^15.6.2",
+        "react-native-iphone-x-helper": "^1.0.3"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.48.4"
       }
     },
     "node_modules/react-native-linear-gradient": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "react-native-animated-pagination-dots": "^0.1.73",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-global-props": "^1.1.5",
+    "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-linear-gradient": "^2.8.3",
     "react-native-modern-datepicker": "^1.0.0-beta.91",
     "react-native-pager-view": "^6.8.1",

--- a/stores/leenkStore.ts
+++ b/stores/leenkStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 
 type Store = {
   leenkImage: string | null;
-  setLeenkImage: (uri: string) => void;
+  setLeenkImage: (uri: string | null) => void;
   resetLeenkImage: () => void;
 };
 

--- a/stores/modalStore.ts
+++ b/stores/modalStore.ts
@@ -11,7 +11,7 @@ type ModalType =
   | 'feedReport'
   | 'leenkKick'
   | 'leenkClose'
-  | 'leenkEarlyClose'
+  | 'leenkFinish'
   | 'leenkLeave'
   | 'leenkReport'
   | null;

--- a/stores/participantStore.ts
+++ b/stores/participantStore.ts
@@ -1,26 +1,49 @@
-import { LeenkDataType } from '@/constants/mockUserData';
 import { create } from 'zustand';
+import { LeenkParticipantItem } from '@/types/leenk';
 
 interface ParticipantStore {
-  selectedUsers: LeenkDataType[];
+  selectedUsers: LeenkParticipantItem[];
   isSelectionMode: boolean;
-  toggleUser: (user: LeenkDataType) => void;
+
+  // actions
+  toggleUser: (user: LeenkParticipantItem) => void;
+  removeUserById: (userId: number) => void;
   resetSelection: () => void;
   startSelection: () => void;
+  stopSelection: () => void;
+
+  // selectors
+  isSelected: (userId: number) => boolean;
 }
 
-export const useParticipantStore = create<ParticipantStore>((set) => ({
+export const useParticipantStore = create<ParticipantStore>((set, get) => ({
   selectedUsers: [],
   isSelectionMode: false,
+
   toggleUser: (user) =>
     set((state) => {
-      const exists = state.selectedUsers.some((u) => u.id === user.id);
+      const uid = user.participant.userId;
+      const exists = state.selectedUsers.some(
+        (u) => u.participant.userId === uid,
+      );
       return {
         selectedUsers: exists
-          ? state.selectedUsers.filter((u) => u.id !== user.id)
+          ? state.selectedUsers.filter((u) => u.participant.userId !== uid)
           : [...state.selectedUsers, user],
       };
     }),
+
+  removeUserById: (userId) =>
+    set((state) => ({
+      selectedUsers: state.selectedUsers.filter(
+        (u) => u.participant.userId !== userId,
+      ),
+    })),
+
   resetSelection: () => set({ selectedUsers: [], isSelectionMode: false }),
   startSelection: () => set({ isSelectionMode: true }),
+  stopSelection: () => set({ isSelectionMode: false }),
+
+  isSelected: (userId) =>
+    get().selectedUsers.some((u) => u.participant.userId === userId),
 }));

--- a/stores/participantStore.ts
+++ b/stores/participantStore.ts
@@ -56,6 +56,9 @@ export const useParticipantStore = create<ParticipantStore>((set, get) => ({
       participants: state.participants.filter(
         (p) => !ids.includes(p.participant.userId),
       ),
+      selectedUsers: state.selectedUsers.filter(
+        (u) => !ids.includes(u.participant.userId),
+      ),
     })),
 
   isSelected: (userId) =>

--- a/stores/participantStore.ts
+++ b/stores/participantStore.ts
@@ -2,8 +2,10 @@ import { create } from 'zustand';
 import { LeenkParticipantItem } from '@/types/leenk';
 
 interface ParticipantStore {
+  // states
   selectedUsers: LeenkParticipantItem[];
   isSelectionMode: boolean;
+  participants: LeenkParticipantItem[];
 
   // actions
   toggleUser: (user: LeenkParticipantItem) => void;
@@ -12,6 +14,9 @@ interface ParticipantStore {
   startSelection: () => void;
   stopSelection: () => void;
 
+  setParticipants: (list: LeenkParticipantItem[]) => void;
+  removeParticipantsByIds: (ids: number[]) => void;
+
   // selectors
   isSelected: (userId: number) => boolean;
 }
@@ -19,6 +24,7 @@ interface ParticipantStore {
 export const useParticipantStore = create<ParticipantStore>((set, get) => ({
   selectedUsers: [],
   isSelectionMode: false,
+  participants: [],
 
   toggleUser: (user) =>
     set((state) => {
@@ -43,6 +49,14 @@ export const useParticipantStore = create<ParticipantStore>((set, get) => ({
   resetSelection: () => set({ selectedUsers: [], isSelectionMode: false }),
   startSelection: () => set({ isSelectionMode: true }),
   stopSelection: () => set({ isSelectionMode: false }),
+
+  setParticipants: (list) => set({ participants: list }),
+  removeParticipantsByIds: (ids) =>
+    set((state) => ({
+      participants: state.participants.filter(
+        (p) => !ids.includes(p.participant.userId),
+      ),
+    })),
 
   isSelected: (userId) =>
     get().selectedUsers.some((u) => u.participant.userId === userId),

--- a/types/leenk.ts
+++ b/types/leenk.ts
@@ -47,3 +47,12 @@ export interface LeenkParticipantItem {
 export interface LeenkParticipantsData {
   participants: LeenkParticipantItem[];
 }
+
+export interface UpdateLeenkPayload {
+  title?: string;
+  content?: string;
+  placeName?: string;
+  startTime?: string;
+  maxParticipants?: number;
+  mediaUrl?: string;
+}

--- a/types/leenk.ts
+++ b/types/leenk.ts
@@ -22,7 +22,7 @@ export interface LeenkListResponse {
 
 export interface LeenkDetail {
   id: number;
-  status: 'RECRUITING' | 'CLOSED' | 'FINISHED';
+  status: LeenkStatus;
   author: Author;
   kakaoId: string;
   title: string;
@@ -58,3 +58,5 @@ export interface UpdateLeenkPayload {
   maxParticipants?: number;
   mediaUrl?: string;
 }
+
+export type LeenkStatus = 'RECRUITING' | 'CLOSED' | 'FINISHED';

--- a/types/leenk.ts
+++ b/types/leenk.ts
@@ -34,6 +34,7 @@ export interface LeenkDetail {
   mediaUrl: string;
   createdAt: string;
   updatedAt: string;
+  isParticipated: boolean;
 }
 
 export interface LeenkParticipantItem {

--- a/types/leenk.ts
+++ b/types/leenk.ts
@@ -22,6 +22,7 @@ export interface LeenkListResponse {
 
 export interface LeenkDetail {
   id: number;
+  status: 'RECRUITING' | 'CLOSED' | 'FINISHED';
   author: Author;
   kakaoId: string;
   title: string;

--- a/types/leenk.ts
+++ b/types/leenk.ts
@@ -1,0 +1,49 @@
+export interface Author {
+  userId: number;
+  profileImage: string;
+  name: string;
+}
+
+export interface Leenk {
+  leenkId: number;
+  author: Author;
+  title: string;
+  currentParticipants: number;
+  maxParticipants: number;
+  startTime: string;
+  createdAt: string;
+  updatedAt: string;
+  thumbNail: string;
+}
+
+export interface LeenkListResponse {
+  leenks: Leenk[];
+}
+
+export interface LeenkDetail {
+  id: number;
+  author: Author;
+  kakaoId: string;
+  title: string;
+  placeName: string;
+  currentParticipants: number;
+  maxParticipants: number;
+  startTime: string;
+  content: string;
+  mediaUrl: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface LeenkParticipantItem {
+  participant: Author;
+  kakaoTalkId: string;
+  currentParticipants: number;
+  maxParticipants: number;
+  joinedAt: string;
+  isHost: boolean;
+}
+
+export interface LeenkParticipantsData {
+  participants: LeenkParticipantItem[];
+}

--- a/utils/format-date.ts
+++ b/utils/format-date.ts
@@ -13,15 +13,15 @@ export function formatDate(iso: string): string {
 
 export function formatMonthDayHour(iso: string): string {
   const date = new Date(iso);
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
-  const hour = date.getHours();
+  const month = date.getUTCMonth() + 1;
+  const day = date.getUTCDate();
+  const hour = date.getUTCHours();
 
   return `${month}월 ${day}일 ${hour}시`;
 }
 
 dayjs.extend(relativeTime);
-dayjs.locale('ko'); // '몇 분 전' 등 한글로
+dayjs.locale('ko');
 
 export const formatRelativeTime = (date: string) => {
   return dayjs(date).fromNow(); // ex: '2분 전'

--- a/utils/format-date.ts
+++ b/utils/format-date.ts
@@ -26,3 +26,17 @@ dayjs.locale('ko');
 export const formatRelativeTime = (date: string) => {
   return dayjs(date).fromNow(); // ex: '2분 전'
 };
+
+// ISO 문자열로 변환
+export const toISODateTime = (d: Date) =>
+  [
+    d.getFullYear(),
+    String(d.getMonth() + 1).padStart(2, '0'),
+    String(d.getDate()).padStart(2, '0'),
+  ].join('-') +
+  'T' +
+  [
+    String(d.getHours()).padStart(2, '0'),
+    String(d.getMinutes()).padStart(2, '0'),
+    '00',
+  ].join(':');

--- a/utils/format-date.ts
+++ b/utils/format-date.ts
@@ -11,6 +11,15 @@ export function formatDate(iso: string): string {
   return `${year}년 ${month}월 ${day}일`;
 }
 
+export function formatMonthDayHour(iso: string): string {
+  const date = new Date(iso);
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const hour = date.getHours();
+
+  return `${month}월 ${day}일 ${hour}시`;
+}
+
 dayjs.extend(relativeTime);
 dayjs.locale('ko'); // '몇 분 전' 등 한글로
 

--- a/utils/tokenStorage.ts
+++ b/utils/tokenStorage.ts
@@ -10,7 +10,10 @@ const TEMP_ACCESS_TOKEN_KEY = 'temp_access_token';
 // Access Token
 export const saveAccessToken = async (token: string) => {
   if (Platform.OS === 'web') return;
-
+  if (typeof token !== 'string') {
+    console.error('[SecureStore] 저장 실패 - token이 문자열 아님:', token);
+    return;
+  }
   try {
     if (__DEV__) {
       console.log('[SecureStore] saveAccessToken 호출됨');


### PR DESCRIPTION
- closed #40 

## 📝 Work Description

- 링크의 api들을 연결 했습니다... 
- 카카오 로그인 에러 및 약관 동의 에러를 해결했습니다!

## 📸 Screenshot
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img width="300" src="이미지 주소" /> -->

**- 링크 리스트**
https://github.com/user-attachments/assets/a073c2cd-d57d-4ef1-8f5a-eac1f1ca3311

**- 링크 포스팅**
1. 작성
https://github.com/user-attachments/assets/65fd0ad7-156e-4d3b-aa1a-a0d55c7622ea
2. 수정
https://github.com/user-attachments/assets/8b955507-b5ee-4867-ba2c-fcb6f96b1fc2

**- 링크 상세 페이지** 
1. 작성자
  - 내보내기
  https://github.com/user-attachments/assets/bd10cda2-3842-4b4f-816f-69f583a7c054
  - 링크 모임/ 모집 종료
  https://github.com/user-attachments/assets/6f13f84a-93a9-4095-9343-3e1ccee42451
  <img width="1080" height="2130" alt="image" src="https://github.com/user-attachments/assets/f2047127-d893-44bb-b2ea-0bb229d29b3e" />
  (영상에서는 링크 종료하기까지 보여주려고 안 막았는데 지금은 링크 시작 시간 전에는 종료 못하도록 막아놨어요!)

2. 참여자
  - 링크 참여하기
  https://github.com/user-attachments/assets/cedf1017-2143-4054-9d43-96c59df8f7b3
  - 링크 나가기
  https://github.com/user-attachments/assets/81e6a28c-c54c-429a-9ead-2bc9c743d730

## 🚨Issue
카카오 로그인 2번 눌러야 하는 문제랑 약관 동의 문제는 리프레스 토큰 때문이엇던 거 같아요 그거 고치니까 해결이 된.. 그런 사연..

## 📣 To Reviewers
링크 알림 구현도 여기서 할 뻔 했는데 조금 남은 정신 머리로 막앗어요.. 휴..
상세 페이지가 좀 복잡한데 일단 분리할만한 것들은 최대한 분리 했습니다 ㅜ.ㅜ 
해당 페이지 플로우가 조금 복잡해서 어쩔 수 없기도 한데.. 일단 나중에 좀 더 깔끔하게 정리해 보겠습니다...  

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 링크(Leenk) 목록/내 목록: 무한스크롤·당겨서 새로고침, 상세조회 기반 참여/나가기/모집종료/링크종료, 참여자 목록 조회·강퇴, 신고 및 공유(딥링크) 지원
  - 글쓰기(생성/수정) 통합: 이미지 업로드·기본 이미지 선택, 인원 스테퍼 도입

- Refactor
  - 목록/상세/참여자 UI를 단일 데이터 모델로 재구성, 모달 로딩 상태 및 헤더 권한 제어, 키보드/입력 UX 개선(iOS/Android)

- Chores
  - 로그인/토큰 저장·자동갱신 안정화 및 초기 토큰 정리, 기본 이미지 URL 추가, 일부 외부 의존성 추가 (키보드 스크롤)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->