### PR TITLE
LNK-M-25 QA 수정 

### DIFF
--- a/api/leenk/leenk.get.api.ts
+++ b/api/leenk/leenk.get.api.ts
@@ -5,6 +5,9 @@ import {
 } from '@/types/leenk';
 import api from '@/api/api';
 import { ApiResponse } from '@/api/api-type';
+import { Pageable } from '@/types/pageable';
+
+type OtherUserLeenkListApi = LeenkListResponse & { pageable: Pageable };
 
 // 링크 전체 조회
 export const getLeenkList = async (
@@ -52,20 +55,13 @@ export const getOtherUserLeenkList = async (
   userId: number,
   pageNumber: number,
   pageSize: number,
-) => {
-  const res = await api.get<ApiResponse<LeenkListResponse>>(
+): Promise<OtherUserLeenkListApi> => {
+  const res = await api.get<ApiResponse<OtherUserLeenkListApi>>(
     `/leenks/participated/users/${userId}`,
-    {
-      params: {
-        pageNumber,
-        pageSize,
-      },
-    },
+    { params: { pageNumber, pageSize } },
   );
-
   if (__DEV__)
     console.log(`유저 ${userId}가 참여한 링크 목록 조회 : `, res.data);
-
   return res.data.data;
 };
 

--- a/api/leenk/leenk.get.api.ts
+++ b/api/leenk/leenk.get.api.ts
@@ -47,6 +47,28 @@ export const getMyLeenkList = async (pageNumber: number, pageSize: number) => {
   return res.data.data;
 };
 
+// 다른 유저가 참여한 링크 조회
+export const getOtherUserLeenkList = async (
+  userId: number,
+  pageNumber: number,
+  pageSize: number,
+) => {
+  const res = await api.get<ApiResponse<LeenkListResponse>>(
+    `/leenks/participated/users/${userId}`,
+    {
+      params: {
+        pageNumber,
+        pageSize,
+      },
+    },
+  );
+
+  if (__DEV__)
+    console.log(`유저 ${userId}가 참여한 링크 목록 조회 : `, res.data);
+
+  return res.data.data;
+};
+
 // 링크 상세 조회
 export const getLeenkDetail = async (leenkId: number) => {
   const res = await api.get<ApiResponse<LeenkDetail>>(`/leenks/${leenkId}`);

--- a/app/(post)/feed/link-members/index.tsx
+++ b/app/(post)/feed/link-members/index.tsx
@@ -15,7 +15,7 @@ import MemberBadgeList from '@/components/feed/MemberBadgeList';
 import { height, width } from '@/theme/globalStyles';
 import { useFeedWriteStore } from '@/stores/feedWriteStore';
 import { getAllUsers } from '@/api/feed/feed.api';
-import { CONTAINER_PADDING, FEED_PADDING } from '@/constants';
+import { FEED_PADDING } from '@/constants';
 import colors from '@/theme/color';
 import styled from 'styled-components/native';
 import {

--- a/app/(post)/feed/write.tsx
+++ b/app/(post)/feed/write.tsx
@@ -5,7 +5,6 @@ import {
   ScrollView,
   Platform,
   KeyboardAvoidingView,
-  TouchableWithoutFeedback,
   Keyboard,
   Pressable,
   StyleSheet,

--- a/app/(post)/leenk.tsx
+++ b/app/(post)/leenk.tsx
@@ -33,7 +33,6 @@ import { getPresignedUrl } from '@/api/file/s3Upload';
 import { useToastStore } from '@/stores/toastStore';
 import { updateLeenk } from '@/api/leenk/leenk.patch.api';
 import { getLeenkDetail } from '@/api/leenk/leenk.get.api';
-import { InteractionManager } from 'react-native';
 
 export default function PostLeenkPage() {
   const router = useRouter();

--- a/app/(post)/leenk.tsx
+++ b/app/(post)/leenk.tsx
@@ -33,6 +33,7 @@ import { getPresignedUrl } from '@/api/file/s3Upload';
 import { useToastStore } from '@/stores/toastStore';
 import { updateLeenk } from '@/api/leenk/leenk.patch.api';
 import { getLeenkDetail } from '@/api/leenk/leenk.get.api';
+import { InteractionManager } from 'react-native';
 
 export default function PostLeenkPage() {
   const router = useRouter();

--- a/app/(post)/leenk/[id]/index.tsx
+++ b/app/(post)/leenk/[id]/index.tsx
@@ -293,6 +293,7 @@ export default function LeenkDetailPage() {
         style={{
           position: 'absolute',
           width: '100%',
+          top: 35,
           zIndex: 9999,
           paddingHorizontal: width * CONTAINER_PADDING,
         }}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -77,7 +77,11 @@ function RootLayoutNav() {
   const pathname = usePathname();
 
   // 일부 페이지는 상단 SafeAreaView 배경을 제외하기 위한 패턴
-  const excludeSafeAreaPages = ['/feed/write', /^\/feed\/[^/]+$/];
+  const excludeSafeAreaPages = [
+    '/feed/write',
+    /^\/feed\/[^/]+$/,
+    /^\/leenk\/[^/]+$/,
+  ];
   const isExcluded = excludeSafeAreaPages.some((pattern) =>
     pattern instanceof RegExp ? pattern.test(pathname) : pattern === pathname,
   );

--- a/app/account/my-feed.tsx
+++ b/app/account/my-feed.tsx
@@ -16,7 +16,7 @@ export default function MyFeedPage() {
   return (
     <ContainerWithNoPadding>
       <View style={{ paddingHorizontal: FEED_PADDING * width }}>
-        <Header RightSection="SETTING" />
+        <Header />
         <TabMenu
           activeTab={tab}
           onTabChange={(newTab: string) => {

--- a/app/users/[id]/index.tsx
+++ b/app/users/[id]/index.tsx
@@ -99,7 +99,12 @@ export default function MyPage() {
       />
       <MyPageButton
         text="참여한 모임"
-        onPress={() => router.push('/account/my-leenk')}
+        onPress={() =>
+          router.push({
+            pathname: '/users/leenk',
+            params: { userId: id },
+          })
+        }
       />
       {!isMyProfile && (
         <MenuModal

--- a/app/users/[id]/index.tsx
+++ b/app/users/[id]/index.tsx
@@ -97,10 +97,10 @@ export default function MyPage() {
           });
         }}
       />
-      {/* <MyPageButton
+      <MyPageButton
         text="참여한 모임"
         onPress={() => router.push('/account/my-leenk')}
-      /> */}
+      />
       {!isMyProfile && (
         <MenuModal
           visible={modalType === 'menu'}

--- a/app/users/[id]/index.tsx
+++ b/app/users/[id]/index.tsx
@@ -132,5 +132,5 @@ const Container = styled.View`
   align-items: center;
   background-color: ${colors.bg[2]};
   gap: ${13 * height}px;
-  padding-horizontal: ${20 * width}px;
+  padding: 0 ${20 * width}px;
 `;

--- a/app/users/feed/index.tsx
+++ b/app/users/feed/index.tsx
@@ -1,4 +1,3 @@
-import { Container } from '@/app/(post)/feed';
 import { FeedCard, Header, Loading } from '@/components';
 import TabMenu from '@/components/common/TabMenu';
 import { FlatList } from 'react-native';

--- a/app/users/feed/index.tsx
+++ b/app/users/feed/index.tsx
@@ -72,7 +72,7 @@ export default function OtherUserProfilePage() {
   );
 }
 
-const Content = styled.View`
+export const Content = styled.View`
   flex: 1;
   margin-top: ${8 * height}px;
 `;

--- a/app/users/leenk/index.tsx
+++ b/app/users/leenk/index.tsx
@@ -1,0 +1,85 @@
+import React, { useRef } from 'react';
+import { View } from 'react-native';
+import styled from 'styled-components/native';
+import { useLocalSearchParams } from 'expo-router';
+
+import { Header, Loading } from '@/components';
+import { height, width } from '@/theme/globalStyles';
+import { FEED_PADDING } from '@/constants';
+
+import useLeenkList from '@/hooks/useLeenkList';
+import { LeenkList, Separator } from '@/app/(page)/leenk';
+import { LeenkListItem } from '@/components';
+import colors from '@/theme/color';
+
+export default function OtherUserLeenkPage() {
+  const { userId } = useLocalSearchParams<{ userId: string }>();
+  const uid = Number(userId);
+
+  const {
+    data: leenks,
+    loadMore,
+    isLoading,
+    isRefreshing,
+    refresh,
+  } = useLeenkList({
+    type: 'userLeenk', // 다른 유저가 '참여한' 모임
+    userId: uid,
+    pageSize: 10,
+  });
+
+  const listRef = useRef<any>(null);
+  const onEndReachedCalledDuringMomentum = useRef(false);
+
+  if (leenks.length === 0 && isLoading) return <Loading />;
+
+  return (
+    <Container>
+      <View style={{ paddingHorizontal: FEED_PADDING * width }}>
+        <Header>참여한 모임</Header>
+      </View>
+
+      <Content>
+        <LeenkList
+          ref={listRef}
+          data={leenks}
+          keyExtractor={(item) => String(item.leenkId)}
+          renderItem={({ item }) => <LeenkListItem item={item} />}
+          ItemSeparatorComponent={() => <Separator />}
+          onEndReachedThreshold={0.3}
+          onEndReached={() => {
+            if (!onEndReachedCalledDuringMomentum.current) {
+              loadMore();
+              onEndReachedCalledDuringMomentum.current = true;
+            }
+          }}
+          onMomentumScrollBegin={() => {
+            onEndReachedCalledDuringMomentum.current = false;
+          }}
+          refreshing={isRefreshing}
+          onRefresh={refresh}
+          showsVerticalScrollIndicator
+          ListFooterComponent={
+            <View
+              style={{ height: 60 * height, opacity: isLoading ? 0.6 : 0 }}
+            />
+          }
+          contentContainerStyle={{
+            paddingHorizontal: FEED_PADDING * width,
+            paddingBottom: 100 * height,
+          }}
+        />
+      </Content>
+    </Container>
+  );
+}
+
+const Container = styled.View`
+  flex: 1;
+  background-color: ${colors.gray[50]};
+`;
+
+const Content = styled.View`
+  flex: 1;
+  margin-top: ${16 * height}px;
+`;

--- a/components/Modal/MenuModal.tsx
+++ b/components/Modal/MenuModal.tsx
@@ -10,7 +10,7 @@ import {
   height,
 } from '@/theme/globalStyles';
 import colors from '@/theme/color';
-import { LeenkIcon, FeedIcon } from '@/assets';
+import { LeenkIcon, FeedIcon, MenuLeenkIcon, MenuFeedIcon } from '@/assets';
 
 interface MenuModalProps {
   visible: boolean;
@@ -61,7 +61,7 @@ export default function MenuModal({
               <MenuItemWrapper onPress={onPressFirst}>
                 {({ pressed }) => (
                   <MenuItem pressed={pressed} $isWrite={isWrite}>
-                    <LeenkIcon
+                    <MenuLeenkIcon
                       width={20 * width}
                       height={20 * width}
                       stroke={colors.primary}
@@ -74,7 +74,7 @@ export default function MenuModal({
               <MenuItemWrapper onPress={onPressSecond}>
                 {({ pressed }) => (
                   <MenuItem pressed={pressed} $isWrite={isWrite}>
-                    <FeedIcon
+                    <MenuFeedIcon
                       width={20 * width}
                       height={20 * width}
                       stroke={colors.primary}
@@ -144,11 +144,15 @@ const MenuContainer = styled.View<{
         right: ${20 * width}px;
         align-items: center;
       `}
-  width: ${({ $isWrite }) => ($isWrite ? 134 * width : 100 * width)}px;
-  padding: ${8 * height}px ${10 * width}px;
+  width: ${({ $isWrite }) => ($isWrite ? 'auto' : `${100 * width}px`)};
+
+  padding: ${({ $isWrite }) =>
+    $isWrite
+      ? `${8 * height}px ${8 * width}px`
+      : `${6 * height}px ${10 * width}px`};
   background-color: ${colors.white};
   border-radius: ${radius.md}px;
-  gap: ${4 * height}px;
+  gap: ${({ $isWrite }) => ($isWrite ? `${6 * height}px` : `${4 * height}px`)};
   margin-bottom: ${({ $bottomMargin }) => $bottomMargin}px;
   /* Android */
   elevation: 6;
@@ -158,12 +162,12 @@ const MenuItem = styled.View<{ pressed: boolean; $isWrite: boolean }>`
   flex-direction: row;
   align-items: center;
   justify-content: ${({ $isWrite }) => ($isWrite ? 'flex-start' : 'center')};
-  padding: ${({ pressed }) =>
-    pressed
-      ? `${4 * height}px ${12 * width}px`
-      : `${4 * height}px ${4 * width}px`};
-  border-radius: ${({ pressed }) => (pressed ? radius.sm : 0)}px;
-  gap: ${({ $isWrite }) => ($isWrite ? 6 * width : 0)}px;
+  padding: ${({ pressed, $isWrite }) =>
+    !$isWrite && pressed
+      ? `${5 * height}px ${12 * width}px`
+      : `${5 * height}px ${6 * width}px`};
+  border-radius: ${({ pressed }) => (pressed ? radius.xs : 0)}px;
+  gap: ${({ $isWrite }) => ($isWrite ? 10 * width : 0)}px;
   background-color: ${({ pressed }) =>
     pressed ? colors.bg[3] : 'transparent'};
 `;

--- a/components/common/Textarea.tsx
+++ b/components/common/Textarea.tsx
@@ -14,6 +14,7 @@ interface TextareaProps extends TextInputProps {
   maxHeight?: number;
   isRequired?: boolean;
   fontSizeKey?: keyof typeof fontSize;
+  textFontKey?: keyof typeof fonts;
   accessoryID?: string;
 }
 
@@ -29,6 +30,7 @@ export default function Textarea({
   isRequired = false,
   onChangeText,
   fontSizeKey = 'md',
+  textFontKey = 'Regular',
   accessoryID,
   ...props
 }: TextareaProps) {
@@ -56,6 +58,7 @@ export default function Textarea({
           maxHeight={maxHeight}
           onChangeText={onChangeText}
           fontSizeKey={fontSizeKey}
+          fontFamilyKey={textFontKey}
           onFocus={(e) => {
             setFocused(true);
             props.onFocus?.(e);
@@ -99,6 +102,7 @@ const StyledTextarea = styled.TextInput<{
   minHeight?: number;
   maxHeight?: number;
   fontSizeKey: keyof typeof fontSize;
+  fontFamilyKey: keyof typeof fonts;
 }>`
   width: 100%;
   min-height: ${({ minHeight }) =>
@@ -106,7 +110,7 @@ const StyledTextarea = styled.TextInput<{
   max-height: ${({ maxHeight }) =>
     maxHeight ? `${maxHeight * height}px` : `${85 * height}px`};
   font-size: ${({ fontSizeKey }) => fontSize[fontSizeKey]}px;
-  font-family: ${fonts.Bold};
+  font-family: ${({ fontFamilyKey }) => fonts[fontFamilyKey]};
   color: ${({ isDark }) => (isDark ? colors.white : colors.black)};
   text-align-vertical: top;
 `;

--- a/components/feed/write/DescriptionContent.tsx
+++ b/components/feed/write/DescriptionContent.tsx
@@ -26,6 +26,7 @@ export default function DescriptionContent({
           maxLength={100}
           value={value}
           onChangeText={onChange}
+          textFontKey="Bold"
         />
       </View>
     );

--- a/components/index.tsx
+++ b/components/index.tsx
@@ -22,6 +22,9 @@ import PopupModal from '@/components/Modal/PopupModal';
 import Loading from '@/components/common/Loading';
 import BottomSheetModal from '@/components/Modal/BottomSheetModal';
 import OnBoarding from '@/components/OnBoarding';
+import LeenkDetailModals from '@/components/leenk/LeenkDetailModals';
+import LeenkListItem from '@/components/leenk/LeenkListItem';
+
 export {
   CustomButton,
   Input,
@@ -47,4 +50,6 @@ export {
   Loading,
   BottomSheetModal,
   OnBoarding,
+  LeenkDetailModals,
+  LeenkListItem,
 };

--- a/hooks/useLeenkInfiniteScroll.ts
+++ b/hooks/useLeenkInfiniteScroll.ts
@@ -8,7 +8,7 @@ interface UseLeenkInfiniteScrollProps<T> {
   ) => Promise<PageableResponse<T> & { totalReactionCount?: number }>;
   initialPageNumber?: number;
   pageSize?: number;
-  enabled?: boolean;
+  enabled?: boolean; // 조건부 활성화
 }
 
 export default function useLeenkInfiniteScroll<T extends { leenkId: number }>({
@@ -24,33 +24,34 @@ export default function useLeenkInfiniteScroll<T extends { leenkId: number }>({
   const [totalReactionCount, setTotalReactionCount] = useState(0);
   const [hasError, setHasError] = useState(false);
 
-  const nextPageRef = useRef<number>(initialPageNumber);
+  // 에러 후 자동 재호출 차단 플래그
   const blockedRef = useRef<boolean>(false);
+  const inFlightRef = useRef<boolean>(false);
 
   const loadMore = useCallback(async () => {
     if (!enabled) return;
+    if (inFlightRef.current) return;
     if (isLoading) return;
     if (blockedRef.current) return;
     if (pageable && !pageable.hasNext) return;
 
     setIsLoading(true);
+    inFlightRef.current = true;
     try {
       const pageNumber = pageable ? pageable.pageNumber + 1 : initialPageNumber;
       const res = await fetchFunction(pageNumber, pageSize);
 
       setData((prev) => {
-        const newData = res.data.filter(
+        const newItems = res.data.filter(
           (item) => !prev.some((p) => p.leenkId === item.leenkId),
         );
-        return [...prev, ...newData];
+        return [...prev, ...newItems];
       });
 
       setPageable(res.pageable);
       if (res.totalReactionCount !== undefined) {
         setTotalReactionCount(res.totalReactionCount);
       }
-
-      nextPageRef.current = pageNumber + 1;
       setHasError(false);
     } catch (error) {
       blockedRef.current = true;
@@ -58,6 +59,7 @@ export default function useLeenkInfiniteScroll<T extends { leenkId: number }>({
       console.error('무한 스크롤 에러:', error);
     } finally {
       setIsLoading(false);
+      inFlightRef.current = false;
     }
   }, [
     enabled,
@@ -70,10 +72,12 @@ export default function useLeenkInfiniteScroll<T extends { leenkId: number }>({
 
   const refresh = useCallback(async () => {
     if (!enabled) return;
-    setIsRefreshing(true);
-    try {
-      blockedRef.current = false;
 
+    setIsRefreshing(true);
+    blockedRef.current = false;
+    inFlightRef.current = false;
+
+    try {
       const res = await fetchFunction(initialPageNumber, pageSize);
       setData(res.data);
       setPageable(res.pageable);
@@ -82,6 +86,7 @@ export default function useLeenkInfiniteScroll<T extends { leenkId: number }>({
       }
       setHasError(false);
     } catch (error) {
+      setHasError(true);
       console.error('무한 스크롤 Refresh 에러:', error);
     } finally {
       setIsRefreshing(false);

--- a/hooks/useLeenkInfiniteScroll.ts
+++ b/hooks/useLeenkInfiniteScroll.ts
@@ -1,3 +1,4 @@
+// hooks/useLeenkInfiniteScroll.ts
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Pageable, PageableResponse } from '@/types/pageable';
 
@@ -8,12 +9,14 @@ interface UseLeenkInfiniteScrollProps<T> {
   ) => Promise<PageableResponse<T> & { totalReactionCount?: number }>;
   initialPageNumber?: number;
   pageSize?: number;
+  enabled?: boolean; // ⬅️ 추가
 }
 
 export default function useLeenkInfiniteScroll<T extends { leenkId: number }>({
   fetchFunction,
   initialPageNumber = 0,
   pageSize = 10,
+  enabled = true, // ⬅️ 기본값
 }: UseLeenkInfiniteScrollProps<T>) {
   const [data, setData] = useState<T[]>([]);
   const [pageable, setPageable] = useState<Pageable | null>(null);
@@ -22,11 +25,11 @@ export default function useLeenkInfiniteScroll<T extends { leenkId: number }>({
   const [totalReactionCount, setTotalReactionCount] = useState(0);
   const [hasError, setHasError] = useState(false);
 
-  // 다음 요청 페이지/에러 차단 플래그
   const nextPageRef = useRef<number>(initialPageNumber);
   const blockedRef = useRef<boolean>(false);
 
   const loadMore = useCallback(async () => {
+    if (!enabled) return; // ⬅️ 가드
     if (isLoading) return;
     if (blockedRef.current) return;
     if (pageable && !pageable.hasNext) return;
@@ -51,15 +54,23 @@ export default function useLeenkInfiniteScroll<T extends { leenkId: number }>({
       nextPageRef.current = pageNumber + 1;
       setHasError(false);
     } catch (error) {
-      blockedRef.current = true; // 에러 후 무한 재호출 방지
+      blockedRef.current = true;
       setHasError(true);
       console.error('무한 스크롤 에러:', error);
     } finally {
       setIsLoading(false);
     }
-  }, [fetchFunction, pageable, isLoading, pageSize, initialPageNumber]);
+  }, [
+    enabled,
+    fetchFunction,
+    pageable,
+    isLoading,
+    pageSize,
+    initialPageNumber,
+  ]);
 
   const refresh = useCallback(async () => {
+    if (!enabled) return; // ⬅️ 가드
     setIsRefreshing(true);
     try {
       blockedRef.current = false;
@@ -76,11 +87,11 @@ export default function useLeenkInfiniteScroll<T extends { leenkId: number }>({
     } finally {
       setIsRefreshing(false);
     }
-  }, [fetchFunction, initialPageNumber, pageSize]);
+  }, [enabled, fetchFunction, initialPageNumber, pageSize]);
 
   useEffect(() => {
-    refresh();
-  }, [refresh]);
+    if (enabled) refresh(); // ⬅️ 준비되면 자동 호출
+  }, [enabled, refresh]);
 
   return {
     data,

--- a/hooks/useLeenkInfiniteScroll.ts
+++ b/hooks/useLeenkInfiniteScroll.ts
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Pageable, PageableResponse } from '@/types/pageable';
+
+interface UseLeenkInfiniteScrollProps<T> {
+  fetchFunction: (
+    pageNumber: number,
+    pageSize: number,
+  ) => Promise<PageableResponse<T> & { totalReactionCount?: number }>;
+  initialPageNumber?: number;
+  pageSize?: number;
+}
+
+export default function useLeenkInfiniteScroll<T extends { leenkId: number }>({
+  fetchFunction,
+  initialPageNumber = 0,
+  pageSize = 10,
+}: UseLeenkInfiniteScrollProps<T>) {
+  const [data, setData] = useState<T[]>([]);
+  const [pageable, setPageable] = useState<Pageable | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [totalReactionCount, setTotalReactionCount] = useState(0);
+  const [hasError, setHasError] = useState(false);
+
+  // 다음 요청 페이지/에러 차단 플래그
+  const nextPageRef = useRef<number>(initialPageNumber);
+  const blockedRef = useRef<boolean>(false);
+
+  const loadMore = useCallback(async () => {
+    if (isLoading) return;
+    if (blockedRef.current) return;
+    if (pageable && !pageable.hasNext) return;
+
+    setIsLoading(true);
+    try {
+      const pageNumber = pageable ? pageable.pageNumber + 1 : initialPageNumber;
+      const res = await fetchFunction(pageNumber, pageSize);
+
+      setData((prev) => {
+        const newData = res.data.filter(
+          (item) => !prev.some((p) => p.leenkId === item.leenkId),
+        );
+        return [...prev, ...newData];
+      });
+
+      setPageable(res.pageable);
+      if (res.totalReactionCount !== undefined) {
+        setTotalReactionCount(res.totalReactionCount);
+      }
+
+      nextPageRef.current = pageNumber + 1;
+      setHasError(false);
+    } catch (error) {
+      blockedRef.current = true; // 에러 후 무한 재호출 방지
+      setHasError(true);
+      console.error('무한 스크롤 에러:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [fetchFunction, pageable, isLoading, pageSize, initialPageNumber]);
+
+  const refresh = useCallback(async () => {
+    setIsRefreshing(true);
+    try {
+      blockedRef.current = false;
+
+      const res = await fetchFunction(initialPageNumber, pageSize);
+      setData(res.data);
+      setPageable(res.pageable);
+      if (res.totalReactionCount !== undefined) {
+        setTotalReactionCount(res.totalReactionCount);
+      }
+      setHasError(false);
+    } catch (error) {
+      console.error('무한 스크롤 Refresh 에러:', error);
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [fetchFunction, initialPageNumber, pageSize]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return {
+    data,
+    totalReactionCount,
+    loadMore,
+    isLoading,
+    isRefreshing,
+    refresh,
+    hasError,
+  };
+}

--- a/hooks/useLeenkInfiniteScroll.ts
+++ b/hooks/useLeenkInfiniteScroll.ts
@@ -1,4 +1,3 @@
-// hooks/useLeenkInfiniteScroll.ts
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Pageable, PageableResponse } from '@/types/pageable';
 
@@ -9,14 +8,14 @@ interface UseLeenkInfiniteScrollProps<T> {
   ) => Promise<PageableResponse<T> & { totalReactionCount?: number }>;
   initialPageNumber?: number;
   pageSize?: number;
-  enabled?: boolean; // ⬅️ 추가
+  enabled?: boolean;
 }
 
 export default function useLeenkInfiniteScroll<T extends { leenkId: number }>({
   fetchFunction,
   initialPageNumber = 0,
   pageSize = 10,
-  enabled = true, // ⬅️ 기본값
+  enabled = true,
 }: UseLeenkInfiniteScrollProps<T>) {
   const [data, setData] = useState<T[]>([]);
   const [pageable, setPageable] = useState<Pageable | null>(null);
@@ -29,7 +28,7 @@ export default function useLeenkInfiniteScroll<T extends { leenkId: number }>({
   const blockedRef = useRef<boolean>(false);
 
   const loadMore = useCallback(async () => {
-    if (!enabled) return; // ⬅️ 가드
+    if (!enabled) return;
     if (isLoading) return;
     if (blockedRef.current) return;
     if (pageable && !pageable.hasNext) return;
@@ -70,7 +69,7 @@ export default function useLeenkInfiniteScroll<T extends { leenkId: number }>({
   ]);
 
   const refresh = useCallback(async () => {
-    if (!enabled) return; // ⬅️ 가드
+    if (!enabled) return;
     setIsRefreshing(true);
     try {
       blockedRef.current = false;
@@ -90,7 +89,7 @@ export default function useLeenkInfiniteScroll<T extends { leenkId: number }>({
   }, [enabled, fetchFunction, initialPageNumber, pageSize]);
 
   useEffect(() => {
-    if (enabled) refresh(); // ⬅️ 준비되면 자동 호출
+    if (enabled) refresh();
   }, [enabled, refresh]);
 
   return {

--- a/hooks/useLeenkList.ts
+++ b/hooks/useLeenkList.ts
@@ -1,0 +1,70 @@
+// hooks/useLeenkList.ts
+import { useCallback } from 'react';
+import useInfiniteScroll from '@/hooks/useInfiniteScroll';
+import { useToastStore } from '@/stores/toastStore';
+import { getOtherUserLeenkList } from '@/api/leenk/leenk.get.api';
+import useLeenkInfiniteScroll from './useLeenkInfiniteScroll';
+
+type LeenkListType = 'userLeenk';
+//   | 'myLeenk'      // TODO: 추후 추가 리팩토링
+//   | 'all';
+
+export type LeenkRow = { leenkId: number } & Record<string, any>;
+
+export interface UseLeenkListOptions {
+  type: LeenkListType;
+  userId?: number;
+  pageSize?: number;
+}
+
+export default function useLeenkList({
+  type,
+  userId,
+  pageSize = 10,
+}: UseLeenkListOptions) {
+  const { showToast } = useToastStore();
+
+  const fetchLeenks = useCallback(
+    async (pageNumber: number, pageSizeArg: number) => {
+      try {
+        let res: any;
+
+        switch (type) {
+          case 'userLeenk': {
+            if (!userId) throw new Error('userId가 필요합니다.');
+            res = await getOtherUserLeenkList(userId, pageNumber, pageSizeArg);
+            break;
+          }
+
+          //   // --- TODO:  추후 추가 예정 ---
+          //   case 'myLeenk':
+          //   case 'all':
+          //   // -------------------------------------
+
+          default:
+            throw new Error('지원하지 않는 타입입니다.');
+        }
+
+        // useInfiniteScroll이 feedId 기반으로 de-dup 하므로 leenkId → feedId 매핑
+        const list: LeenkRow[] = (res?.leenks ?? res?.data ?? []).map(
+          (it: any) => ({ ...it, feedId: it.leenkId }),
+        );
+
+        return {
+          data: list,
+          pageable: res?.pageable,
+        };
+      } catch (err) {
+        console.error('모임 목록 조회 실패:', err);
+        showToast('모임 목록 조회에 실패했어!', 'error');
+        throw err;
+      }
+    },
+    [type, userId, showToast],
+  );
+
+  return useLeenkInfiniteScroll<{ leenkId: number }>({
+    fetchFunction: fetchLeenks,
+    pageSize,
+  });
+}

--- a/hooks/useLeenkList.ts
+++ b/hooks/useLeenkList.ts
@@ -1,15 +1,11 @@
 // hooks/useLeenkList.ts
 import { useCallback } from 'react';
-import useInfiniteScroll from '@/hooks/useInfiniteScroll';
 import { useToastStore } from '@/stores/toastStore';
 import { getOtherUserLeenkList } from '@/api/leenk/leenk.get.api';
 import useLeenkInfiniteScroll from './useLeenkInfiniteScroll';
+import { Leenk } from '@/types/leenk';
 
 type LeenkListType = 'userLeenk';
-//   | 'myLeenk'      // TODO: 추후 추가 리팩토링
-//   | 'all';
-
-export type LeenkRow = { leenkId: number } & Record<string, any>;
 
 export interface UseLeenkListOptions {
   type: LeenkListType;
@@ -26,34 +22,33 @@ export default function useLeenkList({
 
   const fetchLeenks = useCallback(
     async (pageNumber: number, pageSizeArg: number) => {
+      console.log('[useLeenkList] call', {
+        type,
+        userId,
+        pageNumber,
+        pageSizeArg,
+      });
       try {
-        let res: any;
-
-        switch (type) {
-          case 'userLeenk': {
-            if (!userId) throw new Error('userId가 필요합니다.');
-            res = await getOtherUserLeenkList(userId, pageNumber, pageSizeArg);
-            break;
-          }
-
-          //   // --- TODO:  추후 추가 예정 ---
-          //   case 'myLeenk':
-          //   case 'all':
-          //   // -------------------------------------
-
-          default:
-            throw new Error('지원하지 않는 타입입니다.');
+        if (type !== 'userLeenk') throw new Error('지원하지 않는 타입입니다.');
+        if (!userId || Number.isNaN(userId)) {
+          // 아직 userId 준비 전엔 요청하지 않음(안전 장치)
+          return {
+            data: [] as Leenk[],
+            pageable: {
+              pageNumber,
+              pageSize: pageSizeArg,
+              numberOfElements: 0,
+              hasNext: true,
+            } as any,
+          };
         }
 
-        // useInfiniteScroll이 feedId 기반으로 de-dup 하므로 leenkId → feedId 매핑
-        const list: LeenkRow[] = (res?.leenks ?? res?.data ?? []).map(
-          (it: any) => ({ ...it, feedId: it.leenkId }),
+        const res = await getOtherUserLeenkList(
+          userId,
+          pageNumber,
+          pageSizeArg,
         );
-
-        return {
-          data: list,
-          pageable: res?.pageable,
-        };
+        return { data: res.leenks as Leenk[], pageable: res.pageable };
       } catch (err) {
         console.error('모임 목록 조회 실패:', err);
         showToast('모임 목록 조회에 실패했어!', 'error');
@@ -63,8 +58,11 @@ export default function useLeenkList({
     [type, userId, showToast],
   );
 
-  return useLeenkInfiniteScroll<{ leenkId: number }>({
+  const enabled = !!userId && Number.isFinite(userId);
+
+  return useLeenkInfiniteScroll<Leenk>({
     fetchFunction: fetchLeenks,
     pageSize,
+    enabled,
   });
 }

--- a/hooks/useLeenkList.ts
+++ b/hooks/useLeenkList.ts
@@ -5,7 +5,7 @@ import { getOtherUserLeenkList } from '@/api/leenk/leenk.get.api';
 import useLeenkInfiniteScroll from './useLeenkInfiniteScroll';
 import { Leenk } from '@/types/leenk';
 
-type LeenkListType = 'userLeenk';
+type LeenkListType = 'userLeenk'; // TODO: all, myLeenk 추가해서 리팩토링
 
 export interface UseLeenkListOptions {
   type: LeenkListType;


### PR DESCRIPTION
- closed #49 

## 📝 Work Description

- 다른 유저가 참여한 모임 API 연결 
- 메뉴 모달 간격, 패딩 수정 
- 상세 링크 페이지 safe area 영역 확장 
- textarea 컴포넌트 fontFamily 조건부로 스타일링하도록 수정(링크 글쓰기랑 피드 글쓰기 폰트두께가 달라서..)

## 📸 Screenshot
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img width="300" src="이미지 주소" /> -->
<img width="564" height="1062" alt="image" src="https://github.com/user-attachments/assets/6fc9d4eb-76dd-43e7-90ee-282befb7f946" />

<img width="564" height="1062" alt="image" src="https://github.com/user-attachments/assets/b52d43c6-1d35-4ddc-a7d0-41b739d5249a" />

## 🚨Issue

## 📣 To Reviewers
생각해보니까 `useInfiniteScroll` 함수가 feedId 만 받게 되어있어서 leenkId도 받게 수정해야되는데 이게 또 건드리기 무서워서 .. 
그냥 `useLeenkInfiniteScroll` 함수를 추가해서 링크 무한스크롤 함수를 구현했습니다 .. 나중에 하나로 합치도록 리팩토링해볼게욥..

 그리고 링크 리스트 목록 구현을 위해 `useLeenkList` 함수도 추가했습니당. 추후 리팩토링 시 전체 목록, 내가 참여한 모임도 여기에 type 추가해서 리팩토링하면 좋을 것 같아요 !

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 사용자 프로필의 “참여한 모임” 페이지 추가: 무한 스크롤, 당겨서 새로고침, 리스트 및 구분선 표시.
  - 외부 사용자 참여 모임 조회 지원 및 관련 무한스크롤 훅/리스트 훅 추가.

- 스타일/UX
  - 참여 모임 상세 헤더 위치 조정 및 SafeArea 예외 적용.
  - 메뉴 모달 아이콘 교체 및 간격·패딩 조정.
  - iOS 게시글 설명 입력란 폰트 조정 및 일부 화면 패딩 미세 조정.

- 기타
  - 불필요한 import 정리 및 공용 컴포넌트·컴포넌트들 공개(export) 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->