### PR TITLE
LNK-34-leenk 생일 등록 시 날짜 제한 제거

### DIFF
--- a/components/common/Button/ProfileEditButton.tsx
+++ b/components/common/Button/ProfileEditButton.tsx
@@ -31,7 +31,7 @@ export const ProfileEditButton = ({
   const isEmpty = !content || content.trim().length === 0;
   const placeholderText = placeholders[title] || '';
 
-  // 생일이면 YYYY년 M월 D일 포맷
+  // 생일이면 MM월 DD일 포맷 (연도 제외)
   const formattedContent =
     title === '생일' && !isEmpty
       ? dayjs(content, 'YYYY-MM-DD').format('MM월 DD일')

--- a/components/common/Button/ProfileEditButton.tsx
+++ b/components/common/Button/ProfileEditButton.tsx
@@ -34,7 +34,7 @@ export const ProfileEditButton = ({
   // 생일이면 YYYY년 M월 D일 포맷
   const formattedContent =
     title === '생일' && !isEmpty
-      ? dayjs(content, 'YYYY-MM-DD').format('YYYY년 M월 D일')
+      ? dayjs(content, 'YYYY-MM-DD').format('MM월 DD일')
       : content;
 
   const displayText = isEmpty ? placeholderText : formattedContent;

--- a/components/leenk/CalendarButton.tsx
+++ b/components/leenk/CalendarButton.tsx
@@ -39,10 +39,7 @@ export default function CalendarButton({
   const [tempDateStr, setTempDateStr] = useState<string>('');
 
   // 최소 날짜 (leenk 전용)
-  const minDateStr = useMemo(
-    () => getFormatedDate(new Date(), 'YYYY/MM/DD'),
-    [],
-  );
+  const minDateStr = getFormatedDate(new Date(), 'YYYY/MM/DD');
 
   useEffect(() => {
     if (value?.getTime() !== selectedDate?.getTime()) {

--- a/components/leenk/CalendarButton.tsx
+++ b/components/leenk/CalendarButton.tsx
@@ -38,8 +38,11 @@ export default function CalendarButton({
   const [step, setStep] = useState<Step>(null);
   const [tempDateStr, setTempDateStr] = useState<string>('');
 
-  // 날짜 제한값 설정 (미래/과거)
-  const todayStr = useMemo(() => getFormatedDate(new Date(), 'YYYY/MM/DD'), []);
+  // 최소 날짜 (leenk 전용)
+  const minDateStr = useMemo(
+    () => getFormatedDate(new Date(), 'YYYY/MM/DD'),
+    [],
+  );
 
   useEffect(() => {
     if (value?.getTime() !== selectedDate?.getTime()) {
@@ -55,26 +58,25 @@ export default function CalendarButton({
 
   // 날짜 선택 로직
   const handleSelectDate = (dateStr: string) => {
+    const selected = dayjs(dateStr, 'YYYY/MM/DD');
+
     if (mode === 'birthday') {
-      // 생일 모드: 오늘 이후 선택 불가
-      const selected = dayjs(dateStr, 'YYYY/MM/DD');
-      if (selected.isAfter(dayjs(), 'day')) {
-        showToast('오늘 이전 날짜만 선택할 수 있어요!', 'error');
-        return;
-      }
+      // 생일 모드 : 모든 날짜 가능
       commit(selected.toDate());
       setStep(null);
-    } else {
-      // 일반 모드: 다음 단계에서 시간 선택
-      setTempDateStr(dateStr);
-      setStep('time');
+      return;
     }
+
+    // leenk 모드 : 날짜 선택 후 시간 선택으로 이동
+    setTempDateStr(dateStr);
+    setStep('time');
   };
 
   // 시간 선택 로직
   const handleSelectTime = (timeStr: string) => {
     const selected = dayjs(`${tempDateStr} ${timeStr}`, 'YYYY/MM/DD HH:mm');
     const now = dayjs();
+
     if (selected.isSame(now, 'day') && selected.isBefore(now)) {
       const minutesToAdd = 30 - (now.minute() % 30);
       const rounded = now
@@ -93,7 +95,7 @@ export default function CalendarButton({
   // 표시 포맷 변경
   const formattedText = selectedDate
     ? mode === 'birthday'
-      ? dayjs(selectedDate).format('YYYY년 M월 D일')
+      ? dayjs(selectedDate).format('MM월 DD일')
       : dayjs(selectedDate).format('MM월 DD일 HH시 mm분')
     : (placeholder ??
       (mode === 'birthday' ? '생일을 선택해줘' : '모임 일시를 선택해줘'));
@@ -111,8 +113,8 @@ export default function CalendarButton({
       {step === 'date' && (
         <DatePicker
           mode="calendar"
-          minimumDate={mode === 'birthday' ? undefined : todayStr}
-          maximumDate={mode === 'birthday' ? todayStr : undefined}
+          minimumDate={mode === 'leenk' ? minDateStr : undefined}
+          maximumDate={undefined}
           onSelectedChange={handleSelectDate}
           onDateChange={() => {}}
           onMonthYearChange={() => {}}


### PR DESCRIPTION
## 📝 Work Description

- 캘린더 버튼 컴포넌트에서 날짜 제한 제거
- 생일 등록 시 UI에 표시되는 연도 제거

## 📸 Screenshot

https://github.com/user-attachments/assets/8e3a5265-b43d-498f-b5e3-106770f9133a


## 🚨Issue
x

## 📣 To Reviewers
YYYY년 MM월 DD일 -> MM월 DD일로만 UI에 표시되게 수정했습니다! bb 

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 생일 표시 형식 개선: 연도 제외한 MM월 DD일로 표기
  * 같은 날 과거 시간 선택 시 자동 보정(기존 동작 유지)

* **Improvements**
  * 생일 모드에서 미래 날짜 선택 허용
  * 일반 일정(Leenk) 모드에 최소 날짜 제약 적용 및 날짜→시간 선택 흐름 명확화 (생일은 선택 즉시 저장, 일반 일정은 시간 선택으로 진행)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->