### PR TITLE
LNK-31-leenk 생일 축하 알림 api 연결

### DIFF
--- a/api/users/notification.api.ts
+++ b/api/users/notification.api.ts
@@ -32,6 +32,7 @@ export const patchNotificationsSetting = async (
     leenkStatusNotify: boolean;
     newFeedNotify: boolean;
     newReactionNotify: boolean;
+    birthdayNotify: boolean;
   }>,
 ) => {
   const res = await api.patch('/user-setting/notifications', body);

--- a/app/account/notification-list.tsx
+++ b/app/account/notification-list.tsx
@@ -72,11 +72,21 @@ export default function NotificationListPage() {
         ),
       );
 
-      if (notification.content.leenkId || notification.content.feedId) {
-        if (notification.path === 'leenks') {
-          router.push(`/leenk/${notification.content.leenkId}`);
+      const { path, notificationType, content } = notification;
+
+      //  생일 경로 처리
+      if (path === 'birthday') {
+        if (notificationType === 'BIRTHDAY_LETTER') {
+          return router.push('/extra/birthday/letters');
+        }
+        return router.push('/extra');
+      }
+
+      if (content.leenkId || content.feedId) {
+        if (path === 'leenks') {
+          router.push(`/leenk/${content.leenkId}`);
         } else {
-          router.push(`/feed/${notification.content.feedId}`);
+          router.push(`/feed/${content.feedId}`);
         }
       }
     } catch (error) {

--- a/app/account/setting/notifications.tsx
+++ b/app/account/setting/notifications.tsx
@@ -15,6 +15,7 @@ export default function SettingNotificationsPage() {
     newFeedPost: false,
     newLeenkPost: false,
     leenkApplyRequest: false,
+    birthdayNotify: false,
   });
 
   useEffect(() => {
@@ -26,6 +27,7 @@ export default function SettingNotificationsPage() {
           newFeedPost: !!data?.isNewFeedNotify,
           newLeenkPost: !!data?.isNewLeenkNotify,
           leenkApplyRequest: !!data?.isLeenkStatusNotify,
+          birthdayNotify: !!data?.isBirthdayNotify,
         });
         // if (__DEV__) console.log('[알림 설정 불러오기]', data);
       } catch (error) {
@@ -44,6 +46,11 @@ export default function SettingNotificationsPage() {
       key: 'leenkApplyRequest',
       label: '링크 참여자 신청 시',
       apiKey: 'leenkStatusNotify',
+    },
+    {
+      key: 'birthdayNotify',
+      label: '생일 축하',
+      apiKey: 'birthdayNotify',
     },
   ] as const;
 

--- a/components/NotificationListItem.tsx
+++ b/components/NotificationListItem.tsx
@@ -198,6 +198,47 @@ export default function NotificationListItem({
           </>
         );
 
+      case 'BIRTHDAY_ANNOUNCEMENT': {
+        const userName = item.content.birthdayUserName ?? '이름';
+        const rawBody =
+          item.content.body ?? '오늘은 {name}의 생일이야 \n축하해주러 가볼까?';
+
+        // {name}을 실제 이름으로 치환
+        const replacedBody = rawBody.replace('{name}', userName);
+
+        return (
+          <>
+            <TitleText>{replacedBody}</TitleText>
+          </>
+        );
+      }
+
+      case 'BIRTHDAY_CELEBRATE': {
+        const userName = item.content.birthdayUserName ?? '이름';
+        const rawBody = item.content.body ?? '생일 축하해, 멋쟁이 {name}!';
+
+        // {name}을 실제 이름으로 치환
+        const replacedBody = rawBody.replace('{name}', userName);
+        return (
+          <>
+            <TitleText>{replacedBody}</TitleText>
+          </>
+        );
+      }
+
+      case 'BIRTHDAY_LETTER': {
+        const senderName = item.content.senderName ?? '보낸 사람';
+        const rawBody = item.content.body ?? '{name}에게 생일 편지를 받았어!';
+
+        // {name}을 senderName으로 치환
+        const replacedBody = rawBody.replace('{name}', senderName);
+        return (
+          <>
+            <TitleText>{replacedBody}</TitleText>
+          </>
+        );
+      }
+
       default:
         return (
           <>

--- a/components/NotificationListItem.tsx
+++ b/components/NotificationListItem.tsx
@@ -255,7 +255,16 @@ export default function NotificationListItem({
         <StyledItemContent pressed={pressed}>
           <Row>
             <LeftSection>
-              {item.path === 'leenks' ? (
+              {[
+                'BIRTHDAY_ANNOUNCEMENT',
+                'BIRTHDAY_CELEBRATE',
+                'BIRTHDAY_LETTER',
+              ].includes(item.notificationType) ? (
+                <>
+                  <FeedIcon width={16} stroke={colors.primary} />
+                  <TypeText>생일</TypeText>
+                </>
+              ) : item.path === 'leenks' ? (
                 <>
                   <LeenkIcon width={16} stroke={colors.primary} />
                   <TypeText>링크</TypeText>

--- a/components/NotificationListItem.tsx
+++ b/components/NotificationListItem.tsx
@@ -204,7 +204,7 @@ export default function NotificationListItem({
           item.content.body ?? '오늘은 {name}의 생일이야 \n축하해주러 가볼까?';
 
         // {name}을 실제 이름으로 치환
-        const replacedBody = rawBody.replace('{name}', userName);
+        const replacedBody = rawBody.replaceAll('{name}', userName);
 
         return (
           <>
@@ -218,7 +218,7 @@ export default function NotificationListItem({
         const rawBody = item.content.body ?? '생일 축하해, 멋쟁이 {name}!';
 
         // {name}을 실제 이름으로 치환
-        const replacedBody = rawBody.replace('{name}', userName);
+        const replacedBody = rawBody.replaceAll('{name}', userName);
         return (
           <>
             <TitleText>{replacedBody}</TitleText>
@@ -231,7 +231,7 @@ export default function NotificationListItem({
         const rawBody = item.content.body ?? '{name}에게 생일 편지를 받았어!';
 
         // {name}을 senderName으로 치환
-        const replacedBody = rawBody.replace('{name}', senderName);
+        const replacedBody = rawBody.replaceAll('{name}', senderName);
         return (
           <>
             <TitleText>{replacedBody}</TitleText>

--- a/hooks/useNotification.ts
+++ b/hooks/useNotification.ts
@@ -41,6 +41,27 @@ function navigateFromMessage(msg: FirebaseMessagingTypes.RemoteMessage) {
   const isLeenk =
     pathRaw === 'leenks' || pathRaw === 'leenk' || pathRaw === 'link';
   const isFeed = pathRaw === 'feeds' || pathRaw === 'feed';
+  const isBirthday = pathRaw === 'birthday';
+
+  if (isBirthday) {
+    const type = d['notificationType'];
+
+    if (type === 'BIRTHDAY_LETTER') {
+      // 받은 생일 편지 목록
+      router.push('/extra/birthday/letters');
+      return;
+    }
+
+    if (type === 'BIRTHDAY_CELEBRATE' || type === 'BIRTHDAY_ANNOUNCEMENT') {
+      // 생일 메인
+      router.push('/extra');
+      return;
+    }
+
+    // fallback
+    router.push('/extra');
+    return;
+  }
 
   if (!id) {
     // console.log('[FCM] id가 없어서 상세로 이동할 수 없어요:', d);

--- a/types/notification.ts
+++ b/types/notification.ts
@@ -40,6 +40,10 @@ interface NotificationContent {
   placeName?: string;
   startTime?: string;
   leftUserName?: string;
+  senderName?: string;
+  birthdayLetterId?: number;
+  birthdayUserId?: number;
+  birthdayUserName?: string;
 }
 
 type NotificationType =
@@ -56,6 +60,9 @@ type NotificationType =
   | 'LEENK_FINISHED'
   | 'LEENK_STARTED_HOST_REMINDER'
   | 'LEENK_LEFT'
+  | 'BIRTHDAY_LETTER'
+  | 'BIRTHDAY_CELEBRATE'
+  | 'BIRTHDAY_ANNOUNCEMENT'
   | string;
 
 interface Notification {


### PR DESCRIPTION
## 📝 Work Description

- 알림 설정 내에서 '생일 축하' 알림 on/off 토글 추가
- 생일 관련 type의 푸쉬·인앱 알림 클릭 시 해당 페이지로 이동되게 구현


## 📸 Screenshot
- 인앱 알림 조회
<img width="300" alt="image" src="https://github.com/user-attachments/assets/adb74eca-570a-41b5-a13b-55129a140bf5" />

- 알림 설정
<img width="300" alt="image" src="https://github.com/user-attachments/assets/0427e0be-6dd6-4818-8795-c8a04bd50ca7" />

## 🚨Issue
x

## 📣 To Reviewers
인앱 생일 알림의 경우 임시로 피드 아이콘 사용했습니다 ㅠ_ㅠ! 
<img width="300" alt="image" src="https://github.com/user-attachments/assets/9889bef4-70f3-4c4a-99cb-1cbb2576ee59" />


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 알림 설정에 "생일 축하" 토글 추가 — 사용자 설정에서 켜고 끌 수 있습니다.
  * 생일 관련 알림 유형 지원 추가(생일 축하, 생일 공지, 생일 편지).
  * 알림 목록에서 생일 알림에 별도 아이콘/라벨 표시 및 관련 화면으로의 바로가기 라우팅 추가(생일 편지 목록 등).
  * 알림 내용에 발신자/대상 이름을 반영해 사용자에게 읽기 쉬운 메시지 제공.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->