### PR TITLE
[Fix] LNK-36-Leenk 내 피드 공감 시 토스트 메세지가 바로 뜨도록 수정

### DIFF
--- a/app/(page)/extra.tsx
+++ b/app/(page)/extra.tsx
@@ -46,7 +46,7 @@ export default function ExtraPage() {
 
   const handleBirthdayCardPress = useCallback(
     (user: BirthdayUser) => {
-      const isOwn = user.userId === userInfo?.id;
+      const isOwn = user.userId === userInfo?.userId;
 
       if (isOwn) {
         router.push('/extra/birthday/letters');
@@ -58,7 +58,7 @@ export default function ExtraPage() {
       // 다른 사람 생일인 경우 (편지 작성 모달)
       openModal('birthdayLetter', user.userId);
     },
-    [userInfo?.id, openModal, router, setSelectedUserName],
+    [userInfo?.userId, openModal, router, setSelectedUserName],
   );
 
   //  오늘 생일자
@@ -95,7 +95,7 @@ export default function ExtraPage() {
                   <Title>{`${formatTodayMonthDay()} 오늘의 생일자! 🎉`}</Title>
                 )}
                 {todayBirthdayUsers.map((user) => {
-                  const isOwn = user.userId === userInfo?.id;
+                  const isOwn = user.userId === userInfo?.userId;
                   return (
                     <BirthdayCard
                       key={user.userId}

--- a/app/(post)/feed/[id]/index.tsx
+++ b/app/(post)/feed/[id]/index.tsx
@@ -48,7 +48,7 @@ export default function FeedDetailPage() {
   const firstLaunch = useDetailFirstLaunch();
   const [showOnBoarding, setShowOnBoarding] = useState(false);
 
-  const isAuthor = feed?.author.userId === userInfo?.id;
+  const isAuthor = feed?.author.userId === userInfo?.userId;
 
   const handleEdit = () => {
     if (!feed) return;
@@ -190,7 +190,7 @@ export default function FeedDetailPage() {
             feedId={Number(feed.feedId)}
             totalReactionCount={feed.totalReactionCount}
             authorId={feed.author.userId}
-            currentUserId={userInfo?.id}
+            currentUserId={userInfo?.userId}
             flushOnExit
           />
         </RowWrapper>

--- a/app/(post)/leenk/[id]/index.tsx
+++ b/app/(post)/leenk/[id]/index.tsx
@@ -66,8 +66,9 @@ export default function LeenkDetailPage() {
   }, []);
 
   const isAuthor = useMemo(
-    () => (leenkDetail ? leenkDetail.author.userId === userInfo?.id : false),
-    [leenkDetail, userInfo?.id],
+    () =>
+      leenkDetail ? leenkDetail.author.userId === userInfo?.userId : false,
+    [leenkDetail, userInfo?.userId],
   );
 
   const fetchDetail = useCallback(

--- a/app/users/[id]/index.tsx
+++ b/app/users/[id]/index.tsx
@@ -23,7 +23,7 @@ export default function MyPage() {
 
   const viewedId = Number(id);
   const { userInfo } = useUserStore();
-  const myId = userInfo?.id;
+  const myId = userInfo?.userId;
   const isMyProfile = !!myId && viewedId === myId;
 
   const handleBlock = useCallback(() => {

--- a/components/feed/FeedDetailItem.tsx
+++ b/components/feed/FeedDetailItem.tsx
@@ -75,7 +75,7 @@ export default function FeedDetailItem({ feed }: Props) {
   const authorId = feed?.author?.userId ?? 0;
   const authorName = feed?.author?.name ?? '사용자';
   const authorProfile = feed?.author?.profileImage ?? undefined;
-  const isAuthor = authorId === userInfo?.id;
+  const isAuthor = authorId === userInfo?.userId;
   const isAuthorBirthdayToday = feed?.author?.isUserBirthdayToday;
 
   // ─────────────────────────────────────────────
@@ -187,7 +187,7 @@ export default function FeedDetailItem({ feed }: Props) {
             feedId={Number(feed.feedId)}
             totalReactionCount={feed.totalReactionCount ?? 0}
             authorId={authorId}
-            currentUserId={userInfo?.id}
+            currentUserId={userInfo?.userId}
             flushOnExit
           />
         </TopRow>

--- a/hooks/useUserInfo.ts
+++ b/hooks/useUserInfo.ts
@@ -2,7 +2,7 @@ import { getUsersInfo } from '@/api/users/getUsersInfo.api';
 import { useCallback, useState } from 'react';
 
 export interface UserInfo {
-  id: number;
+  userId: number;
   cardinal: number;
   name: string;
   position: 'FE' | 'BE' | 'D' | 'PM';


### PR DESCRIPTION
## 📝 Work Description
- 원래 내 피드 공감 시 api가 요청되지 않고 토스트메세지가 바로 뜨도록 되어 있었는데 갑자기 ,, api 요청이 되는 문제를 발견하였습니다 
- 정보 조회 api dto에서 id가 userId로 바뀌면서 `currentUserId`가 undefined로 찍혀서 if문이 false가 돼서 그랬던 것이었습니다,, 
```
  if (authorId === currentUserId) {
      showToast('내 피드에는 공감할 수 없어!', 'error');
      return;
    }

```


## 📸 Screenshot
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img width="300" src="이미지 주소" /> -->

https://github.com/user-attachments/assets/5d11a664-024b-4831-a0ff-74409bd606c9

## 🚨Issue

## 📣 To Reviewers
id -> userId 로만 바꿔서 딱히 리뷰할 것은 없을 것 같습니다..ㅎㅎ
핫픽스할걸......그랬나

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 게시물 작성자 확인 및 사용자 소유권 판별 로직을 정비하여 프로필, 피드, 즐겨찾기(하트) 및 생일 카드 등에서 소유자 전용 동작과 UI가 올바르게 표시되도록 개선했습니다.
  * 사용자 정보 처리 방식 일관화를 통해 관련 상호작용의 신뢰성과 안정성을 높였습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->