### PR TITLE
[Refactor] Lnk-42-Leenk 로그인 로직 리팩토링

### DIFF
--- a/api/login/apple.api.ts
+++ b/api/login/apple.api.ts
@@ -1,13 +1,28 @@
 import api from '@/api/api';
 
 export const appleLogin = async (idToken: string) => {
-  return api.post(
-    '/apple/login',
-    {},
-    {
-      headers: {
-        'Apple-Identity-Token': idToken,
+  try {
+    const response = await api.post(
+      '/apple/login',
+      {},
+      {
+        headers: {
+          'Apple-Identity-Token': idToken,
+        },
       },
-    },
-  );
+    );
+
+    const { code, message, data } = response.data;
+    return { code, message, data };
+  } catch (error: any) {
+    if (error.response?.data) {
+      const { code, message } = error.response.data;
+      return { code, message };
+    }
+
+    return {
+      code: 0,
+      message: '알 수 없는 오류가 발생했어요',
+    };
+  }
 };

--- a/api/login/kakao.api.ts
+++ b/api/login/kakao.api.ts
@@ -2,8 +2,8 @@ import api from '@/api/api';
 import axios from 'axios';
 
 export type KakaoLoginResult =
-  | { success: true; data: any; code: number; message: string }
-  | { success: false; code: number; message: string };
+  | { data: any; code: number; message: string }
+  | { code: number; message: string };
 
 // Access Token 유효성 검증 (카카오 공식 API)
 const validateKakaoToken = async (accessToken: string) => {
@@ -31,7 +31,6 @@ export const kakaoLogin = async (
   if (typeof accessToken !== 'string') {
     console.error('[1] accessToken이 문자열이 아님');
     return {
-      success: false,
       code: -1,
       message: 'accessToken이 문자열이 아닙니다.',
     };
@@ -60,7 +59,6 @@ export const kakaoLogin = async (
     // console.log('[4] 백엔드 응답 성공:', response.data);
 
     return {
-      success: true,
       code,
       message,
       data,
@@ -73,7 +71,6 @@ export const kakaoLogin = async (
       );
       const { code, message } = error.response.data;
       return {
-        success: false,
         code,
         message,
       };
@@ -82,7 +79,6 @@ export const kakaoLogin = async (
     console.error('[4] 백엔드 예외:', error);
 
     return {
-      success: false,
       code: 0,
       message: '알 수 없는 오류가 발생했어요',
     };

--- a/app/account/setting/account-status.tsx
+++ b/app/account/setting/account-status.tsx
@@ -8,7 +8,7 @@ import { useState } from 'react';
 import styled from 'styled-components/native';
 import { useToastStore } from '@/stores/toastStore';
 import { deleteUser } from '@/api/users/deleteUser.api';
-import { deleteAccessToken } from '@/utils/tokenStorage';
+import { clearAllTokens } from '@/utils/tokenStorage';
 import { useProfileStore } from '@/stores/profileStore';
 
 export default function AccountStatusPage() {
@@ -28,7 +28,7 @@ export default function AccountStatusPage() {
 
   const handleLogoutConfirm = async () => {
     try {
-      await deleteAccessToken();
+      await clearAllTokens();
       reset();
 
       setLogoutModalVisible(false);
@@ -45,7 +45,7 @@ export default function AccountStatusPage() {
   const handleDeleteConfirm = async () => {
     try {
       await deleteUser();
-      await deleteAccessToken();
+      await clearAllTokens();
       reset();
 
       showToast('탈퇴 완료! 이용해주셔서 고마웠어요 :)', 'success');

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -75,6 +75,11 @@ export default function LandingPage() {
     // --- 정상 로그인 ---
     if (code === 1002) {
       // 최초 로그인(회원가입 페이지로 이동)
+      if (!data?.accessToken || !data?.refreshToken) {
+        showToast('토큰 발급 실패', 'error');
+        return;
+      }
+
       await saveAccessToken(data.accessToken);
       await saveRefreshToken(data.refreshToken);
 
@@ -88,8 +93,16 @@ export default function LandingPage() {
 
     if (code === 1003) {
       // 일반 로그인(홈으로 이동)
+      if (!data?.accessToken || !data?.refreshToken) {
+        showToast('토큰 발급 실패', 'error');
+        return;
+      }
+
       await saveAccessToken(data.accessToken);
       await saveRefreshToken(data.refreshToken);
+
+      // SecureStore 반영 대기
+      await new Promise((r) => setTimeout(r, 150));
 
       await registerFcmToken();
       router.replace('/(page)/leenk');
@@ -102,6 +115,7 @@ export default function LandingPage() {
         setWaitModal(true);
         break;
       case 2001:
+        await clearAllTokens();
         if (__DEV__) console.error('서버 인증 에러:', result.message);
         showToast(message, 'error');
         break;
@@ -110,19 +124,22 @@ export default function LandingPage() {
         break;
       default:
         if (__DEV__) console.error('알 수 없는 예외:', code, result.message);
+        await clearAllTokens();
         showToast(message, 'error');
     }
   };
 
   const handleKakaoLogin = async () => {
-    await clearAllTokens();
-
     try {
       const token = await login();
       const accessToken = token?.accessToken;
-      if (!accessToken) return;
+      if (!accessToken) {
+        showToast('카카오 토큰 발급 실패', 'error');
+        return;
+      }
 
       const result = await kakaoLogin(accessToken);
+
       await handleSocialLogin(result);
     } catch (error: any) {
       const serverCode = error?.response?.data?.code;
@@ -137,6 +154,8 @@ export default function LandingPage() {
         return;
       }
 
+      await clearAllTokens();
+      if (__DEV__) console.error('카카오 로그인 실패:', error);
       showToast('카카오 로그인 실패', 'error');
     }
   };
@@ -166,8 +185,9 @@ export default function LandingPage() {
         return;
       }
 
-      const res = await appleLogin(idToken);
-      await handleSocialLogin(res.data);
+      const result = await appleLogin(idToken);
+
+      await handleSocialLogin(result);
     } catch (error: any) {
       if (error?.code === 'ERR_REQUEST_CANCELED') return;
 


### PR DESCRIPTION
## 📝 Work Description

- 로그아웃/탈퇴 시 `accessToken`만 삭제되던 문제 → 모든 토큰이 삭제되도록 수정
- KakaoLogin 응답에서 사용되지 않고 있는 `success` 필드 제거
- apple 로그인 시 응답 처리 구조를 kakao 로그인과 동일하게 수정 (`res.data` -> `result`)


## 📸 Screenshot
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img width="300" src="이미지 주소" /> -->


## 🚨Issue
iOS 환경에서는 SecureStore에 토큰을 최초 저장할 때 반영이 지연되는 현상이 생길 수 있다고 해서... 아래 코드를 임시로 추가해둔 상태입니다 ㅜ.ㅜ 
```
// SecureStore 반영 대기 
await new Promise((r) => setTimeout(r, 150));
```
완전한 해결책은 아닐 수 있다 해서,,, 외에도 더 좋은 방법이 있을지 추가로 찾아보겟습니다.. 

## 📣 To Reviewers
현재 로그아웃 이슈 해결된 건 확인 완료했습니다! b  
애플 로그인만 문제 없이 잘 되는지,, 요 부분만 한번 테스트해주시면 감사하겟습니다.... ㅠ.ㅠ 잘 되기를...


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 소셜 로그인 응답 및 오류 처리 정리로 로그인 안정성 향상
  * 토큰 유무 검증 강화 및 부재 시 명확한 오류 토스트 표시
  * 인증 실패 시 토큰 초기화 및 오류 로그로 상태 일관성 확보
* **개선**
  * 로그인 후 저장소 동기화 지연 보정으로 재시도/네비게이션 신뢰성 향상
  * 애플 로그인 응답 정상화로 오류 처리 일관성 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->