### PR TITLE
Refactor: LNK-54-Leenk 회원가입 플로우 오류 수정

### DIFF
--- a/app/(page)/leenk.tsx
+++ b/app/(page)/leenk.tsx
@@ -18,6 +18,7 @@ import BottomSheetModal from '@/components/Modal/BottomSheetModal';
 import { SubText, TitleText } from '@/components/OnBoarding';
 import { CongratsIcon } from '@/assets';
 import { useDelayedLoading } from '@/hooks/useDelayedLoading';
+import { useAuthFlagStore } from '@/stores/authFlagStore';
 import useFirstLaunch from '@/hooks/useFirstLaunch';
 
 const FOOTER_SPACER = 10 * height;
@@ -43,6 +44,8 @@ export default function LeenkPage() {
   const { userInfo: fetchedUserInfo, refetch } = useUserInfo();
   const { userInfo, setUserInfo } = useUserStore();
 
+  const { justSignedUp, hydrate, clearJustSignedUp } = useAuthFlagStore();
+
   const firstLaunch = useFirstLaunch();
 
   useEffect(() => {
@@ -56,11 +59,16 @@ export default function LeenkPage() {
   }, [fetchedUserInfo, userInfo, setUserInfo]);
 
   useEffect(() => {
+    if (justSignedUp) {
+      setShowWelcomeModal(true);
+      clearJustSignedUp();
+      return;
+    }
+
     if (firstLaunch === true) {
-      // 처음 방문이면 모달 표시
       setShowWelcomeModal(true);
     }
-  }, [firstLaunch]);
+  }, [justSignedUp, firstLaunch]);
 
   useFocusEffect(
     React.useCallback(() => {
@@ -130,6 +138,10 @@ export default function LeenkPage() {
     loading && !pullRefreshing && data.length === 0 && page === 0;
 
   const showDelayedInitialLoader = useDelayedLoading(showInitialLoader);
+
+  useEffect(() => {
+    hydrate();
+  }, []);
 
   return (
     <ContainerWithNoPadding>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,7 +21,9 @@ import { getUsersInfo } from '@/api/users/getUsersInfo.api';
 import { useUserStore } from '@/stores/userStore';
 import { InAppNotificationProvider } from '@/components/InAppNotificationProvider';
 import { LogBox } from 'react-native';
+import { getAuthStatus, clearAllTokens } from '@/utils/tokenStorage';
 import * as Clarity from '@microsoft/react-native-clarity';
+import { saveAuthStatus } from '@/utils/tokenStorage';
 
 export {
   // Catch any errors thrown by the Layout component.
@@ -72,16 +74,28 @@ export default function RootLayout() {
     });
   }, []);
 
-  useEffect(() => {
-    const autoLogin = async () => {
-      if (!kakaoNativeAppKey) return;
+  const didRunRef = useRef(false);
 
+  useEffect(() => {
+    if (didRunRef.current) return;
+    didRunRef.current = true;
+
+    const autoLogin = async () => {
       try {
-        await initializeKakaoSDK(kakaoNativeAppKey);
+        const status = await getAuthStatus();
+
+        if (status === 'REGISTERING') {
+          await clearAllTokens();
+        }
+
+        if (!kakaoNativeAppKey) return;
+
         const accessToken = await getAccessToken();
+
         if (accessToken) {
           const data = await getUsersInfo();
           setUserInfo(data);
+          saveAuthStatus('AUTHENTICATED');
           router.replace('/leenk');
         } else {
           router.replace('/');

--- a/app/account/edit.tsx
+++ b/app/account/edit.tsx
@@ -153,7 +153,7 @@ export default function AccountEdit() {
               value={edituserInfo}
               placeholder={kakaoTalkId}
               onChangeText={(text) => {
-                const filtered = text.replace(/[^a-zA-Z0-9]/g, '');
+                const filtered = text.replace(/[^a-zA-Z0-9._-]/g, '');
                 setEdituserInfo(filtered);
               }}
               maxLength={20}

--- a/app/account/setting/account-status.tsx
+++ b/app/account/setting/account-status.tsx
@@ -10,6 +10,7 @@ import { useToastStore } from '@/stores/toastStore';
 import { deleteUser } from '@/api/users/deleteUser.api';
 import { clearAllTokens } from '@/utils/tokenStorage';
 import { useProfileStore } from '@/stores/profileStore';
+import { saveAuthStatus } from '@/utils/tokenStorage';
 
 export default function AccountStatusPage() {
   const router = useRouter();
@@ -29,6 +30,7 @@ export default function AccountStatusPage() {
   const handleLogoutConfirm = async () => {
     try {
       await clearAllTokens();
+      await saveAuthStatus('NONE');
       reset();
 
       setLogoutModalVisible(false);
@@ -46,6 +48,7 @@ export default function AccountStatusPage() {
     try {
       await deleteUser();
       await clearAllTokens();
+      await saveAuthStatus('NONE');
       reset();
 
       showToast('탈퇴 완료! 이용해주셔서 고마웠어요 :)', 'success');

--- a/app/signup/profile.tsx
+++ b/app/signup/profile.tsx
@@ -30,6 +30,9 @@ import { useToastStore } from '@/stores/toastStore';
 import { registerFcmToken } from '@/components/LandingPage';
 import { saveAuthStatus } from '@/utils/tokenStorage';
 import CalendarButton from '@/components/leenk/CalendarButton';
+import { setJustSignedUp } from '@/utils/authFlagStorage';
+import { useAuthFlagStore } from '@/stores/authFlagStore';
+import { Loading } from '@/components';
 import dayjs from 'dayjs';
 
 export default function ProfilePage() {
@@ -49,6 +52,7 @@ export default function ProfilePage() {
 
   const [kakaoModalVisible, setKakaoModalVisible] = useState(false);
   const [skipModalVisible, setSkipModalVisible] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const router = useRouter();
   const randomMbti = useRandomMbti(2000);
   const insets = useSafeAreaInsets();
@@ -118,6 +122,8 @@ export default function ProfilePage() {
 
   // ----- 다음 -----
   const handleNext = async () => {
+    if (isSubmitting) return;
+
     if (step === 'id') {
       setKakaoModalVisible(true);
     } else if (step === 'photo') {
@@ -128,13 +134,18 @@ export default function ProfilePage() {
       setStep('mbti');
     } else {
       try {
+        setIsSubmitting(true);
+
         await saveProfile();
         await registerFcmToken();
         await saveAuthStatus('AUTHENTICATED');
+        await useAuthFlagStore.getState().setJustSignedUp();
 
         router.replace('/(page)/leenk');
       } catch (e) {
         console.error('[handleNext] 실패:', e);
+      } finally {
+        setIsSubmitting(false);
       }
     }
   };
@@ -148,14 +159,23 @@ export default function ProfilePage() {
   };
 
   const handleSkip = async () => {
+    if (isSubmitting) return;
+
     setSkipModalVisible(false);
     try {
+      setIsSubmitting(true);
+
       await saveProfile();
       await registerFcmToken();
       await saveAuthStatus('AUTHENTICATED');
+      await setJustSignedUp(true);
+      await useAuthFlagStore.getState().setJustSignedUp();
+
       router.replace('/(page)/leenk');
     } catch (error) {
       console.error('[handleSkip] 실패:', error);
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -408,6 +428,8 @@ export default function ProfilePage() {
           <NormalButtons />
         </Animated.View>
       )}
+
+      {isSubmitting && <Loading />}
     </Container>
   );
 }

--- a/app/signup/profile.tsx
+++ b/app/signup/profile.tsx
@@ -28,6 +28,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import useKeyboardAnimation from '@/hooks/useKeyboardAnimation';
 import { useToastStore } from '@/stores/toastStore';
 import { registerFcmToken } from '@/components/LandingPage';
+import { saveAuthStatus } from '@/utils/tokenStorage';
 import CalendarButton from '@/components/leenk/CalendarButton';
 import dayjs from 'dayjs';
 
@@ -90,6 +91,7 @@ export default function ProfilePage() {
           throw new Error('presigned URL 생성에 실패했습니다.');
         }
         const mediaUrl = presignedUrls[0].mediaUrl;
+
         await uploadImageToS3(mediaUrl, profileImage);
 
         try {
@@ -128,7 +130,9 @@ export default function ProfilePage() {
       try {
         await saveProfile();
         await registerFcmToken();
-        router.replace('/(page)/feed');
+        await saveAuthStatus('AUTHENTICATED');
+
+        router.replace('/(page)/leenk');
       } catch (e) {
         console.error('[handleNext] 실패:', e);
       }
@@ -147,11 +151,12 @@ export default function ProfilePage() {
     setSkipModalVisible(false);
     try {
       await saveProfile();
+      await registerFcmToken();
+      await saveAuthStatus('AUTHENTICATED');
+      router.replace('/(page)/leenk');
     } catch (error) {
       console.error('[handleSkip] 실패:', error);
     }
-    await registerFcmToken();
-    router.replace('/(page)/feed');
   };
 
   const handleImagePick = () => {
@@ -174,16 +179,6 @@ export default function ProfilePage() {
           >
             지금은 넘어갈래
           </CustomButton>
-          <PopupModal
-            isOpen={skipModalVisible}
-            onLeftBtn={() => setSkipModalVisible(false)}
-            onRightBtn={handleSkip}
-            mainText="프로필을 나중에 만들래?"
-            subText="마이페이지에서 마저 설정할 수 있어."
-            leftBtnText="취소"
-            rightBtnText="나중에 할래"
-            isCancel={false}
-          />
         </>
       )}
 
@@ -240,6 +235,16 @@ export default function ProfilePage() {
 
   return (
     <Container>
+      <PopupModal
+        isOpen={skipModalVisible}
+        onLeftBtn={() => setSkipModalVisible(false)}
+        onRightBtn={handleSkip}
+        mainText="프로필을 나중에 만들래?"
+        subText="마이페이지에서 마저 설정할 수 있어."
+        leftBtnText="취소"
+        rightBtnText="나중에 할래"
+        isCancel={false}
+      />
       <Scroll
         automaticallyAdjustKeyboardInsets={false}
         keyboardDismissMode="interactive"
@@ -256,7 +261,7 @@ export default function ProfilePage() {
               title="카카오톡 ID를 입력해줘"
               value={kakaoTalkId}
               onChangeText={(text) =>
-                setkakaoTalkId(text.replace(/[^a-zA-Z0-9]/g, ''))
+                setkakaoTalkId(text.replace(/[^a-zA-Z0-9._-]/g, ''))
               }
               placeholder="모임원들과의 연락을 위해 필요해"
               subMessage="ID는 카카오톡 > 친구 추가 > 카카오톡 ID 에서 볼 수 있어."

--- a/app/signup/profile.tsx
+++ b/app/signup/profile.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useRef } from 'react';
 import {
   Platform,
   Animated,
@@ -57,6 +58,13 @@ export default function ProfilePage() {
   const randomMbti = useRandomMbti(2000);
   const insets = useSafeAreaInsets();
   const { showToast } = useToastStore();
+
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const isIOS = Platform.OS === 'ios';
   const androidTranslateY = useKeyboardAnimation(12);
@@ -145,7 +153,7 @@ export default function ProfilePage() {
       } catch (e) {
         console.error('[handleNext] 실패:', e);
       } finally {
-        setIsSubmitting(false);
+        if (mountedRef.current) setIsSubmitting(false);
       }
     }
   };
@@ -175,7 +183,7 @@ export default function ProfilePage() {
     } catch (error) {
       console.error('[handleSkip] 실패:', error);
     } finally {
-      setIsSubmitting(false);
+      if (mountedRef.current) setIsSubmitting(false);
     }
   };
 

--- a/app/signup/terms.tsx
+++ b/app/signup/terms.tsx
@@ -11,7 +11,7 @@ import {
   radius,
   width,
 } from '@/theme/globalStyles';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import styled from 'styled-components/native';
 import { RightArrowIcon } from '@/assets';
 import { useRouter } from 'expo-router';
@@ -63,6 +63,10 @@ export default function TermsPage() {
       showToast('약관 동의에 실패했어.', 'error');
     }
   };
+
+  useEffect(() => {
+    setAllCheck(serviceCheck && infoCheck);
+  }, [serviceCheck, infoCheck]);
 
   return (
     <Container>

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -34,6 +34,7 @@ import { KeyboardAvoidingView, Platform, ScrollView, View } from 'react-native';
 import { AppleLogo } from '@/assets';
 import * as AppleAuthentication from 'expo-apple-authentication';
 import { appleLogin } from '@/api/login/apple.api';
+import { saveAuthStatus } from '@/utils/tokenStorage';
 
 // FCM 토큰 서버 전송 함수
 export const registerFcmToken = async () => {
@@ -82,6 +83,7 @@ export default function LandingPage() {
 
       await saveAccessToken(data.accessToken);
       await saveRefreshToken(data.refreshToken);
+      await saveAuthStatus('REGISTERING');
 
       setName(data.name);
       setPosition(data.position);
@@ -100,6 +102,7 @@ export default function LandingPage() {
 
       await saveAccessToken(data.accessToken);
       await saveRefreshToken(data.refreshToken);
+      await saveAuthStatus('AUTHENTICATED');
 
       // SecureStore 반영 대기
       await new Promise((r) => setTimeout(r, 150));

--- a/stores/authFlagStore.ts
+++ b/stores/authFlagStore.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand';
+import {
+  setJustSignedUp as persistSet,
+  getJustSignedUp,
+  clearJustSignedUp as persistClear,
+} from '@/utils/authFlagStorage';
+
+interface AuthFlagState {
+  justSignedUp: boolean;
+  hydrate: () => Promise<void>;
+  setJustSignedUp: () => Promise<void>;
+  clearJustSignedUp: () => Promise<void>;
+}
+
+export const useAuthFlagStore = create<AuthFlagState>((set) => ({
+  justSignedUp: false,
+
+  hydrate: async () => {
+    const value = await getJustSignedUp();
+    set({ justSignedUp: value });
+  },
+
+  setJustSignedUp: async () => {
+    await persistSet(true);
+    set({ justSignedUp: true });
+  },
+
+  clearJustSignedUp: async () => {
+    await persistClear();
+    set({ justSignedUp: false });
+  },
+}));

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -1,0 +1,4 @@
+export type AuthStatus =
+  | 'NONE' // 비로그인
+  | 'REGISTERING' // 회원가입 진행 중 (임시 토큰)
+  | 'AUTHENTICATED'; // 정상 로그인 완료

--- a/utils/authFlagStorage.ts
+++ b/utils/authFlagStorage.ts
@@ -1,0 +1,16 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const JUST_SIGNED_UP_KEY = 'just_signed_up';
+
+export const setJustSignedUp = async (value: boolean) => {
+  await AsyncStorage.setItem(JUST_SIGNED_UP_KEY, value ? '1' : '0');
+};
+
+export const getJustSignedUp = async (): Promise<boolean> => {
+  const value = await AsyncStorage.getItem(JUST_SIGNED_UP_KEY);
+  return value === '1';
+};
+
+export const clearJustSignedUp = async () => {
+  await AsyncStorage.removeItem(JUST_SIGNED_UP_KEY);
+};

--- a/utils/tokenStorage.ts
+++ b/utils/tokenStorage.ts
@@ -104,18 +104,38 @@ export const deleteTempAccessToken = async () => {
 // Auth Status
 export const saveAuthStatus = async (status: AuthStatus) => {
   if (Platform.OS === 'web') return;
-  await SecureStore.setItemAsync(AUTH_STATUS_KEY, status);
+  try {
+    await SecureStore.setItemAsync(AUTH_STATUS_KEY, status);
+  } catch (err) {
+    console.error('[SecureStore] authStatus 저장 중 에러 발생:', err);
+    throw err;
+  }
 };
 
 export const getAuthStatus = async (): Promise<AuthStatus> => {
   if (Platform.OS === 'web') return 'NONE';
-  const status = await SecureStore.getItemAsync(AUTH_STATUS_KEY);
-  return (status as AuthStatus) ?? 'NONE';
+  try {
+    const status = await SecureStore.getItemAsync(AUTH_STATUS_KEY);
+    if (
+      status === 'NONE' ||
+      status === 'REGISTERING' ||
+      status === 'AUTHENTICATED'
+    )
+      return status;
+    return 'NONE';
+  } catch (err) {
+    console.error('[SecureStore] authStatus 조회 중 에러 발생:', err);
+    return 'NONE';
+  }
 };
 
 export const deleteAuthStatus = async () => {
   if (Platform.OS === 'web') return;
-  await SecureStore.deleteItemAsync(AUTH_STATUS_KEY);
+  try {
+    await SecureStore.deleteItemAsync(AUTH_STATUS_KEY);
+  } catch (err) {
+    console.error('[SecureStore] authStatus 삭제 중 에러 발생:', err);
+  }
 };
 
 // Clear All

--- a/utils/tokenStorage.ts
+++ b/utils/tokenStorage.ts
@@ -1,11 +1,14 @@
 import * as SecureStore from 'expo-secure-store';
 import { Platform } from 'react-native';
+import type { AuthStatus } from '@/types/auth';
 
 const ACCESS_TOKEN_KEY = 'access_token';
 const REFRESH_TOKEN_KEY = 'refresh_token';
 const FCM_TOKEN_KEY = 'fcm_token';
 
 const TEMP_ACCESS_TOKEN_KEY = 'temp_access_token';
+
+const AUTH_STATUS_KEY = 'auth_status';
 
 // Access Token
 export const saveAccessToken = async (token: string) => {
@@ -98,10 +101,28 @@ export const deleteTempAccessToken = async () => {
   await SecureStore.deleteItemAsync(TEMP_ACCESS_TOKEN_KEY);
 };
 
+// Auth Status
+export const saveAuthStatus = async (status: AuthStatus) => {
+  if (Platform.OS === 'web') return;
+  await SecureStore.setItemAsync(AUTH_STATUS_KEY, status);
+};
+
+export const getAuthStatus = async (): Promise<AuthStatus> => {
+  if (Platform.OS === 'web') return 'NONE';
+  const status = await SecureStore.getItemAsync(AUTH_STATUS_KEY);
+  return (status as AuthStatus) ?? 'NONE';
+};
+
+export const deleteAuthStatus = async () => {
+  if (Platform.OS === 'web') return;
+  await SecureStore.deleteItemAsync(AUTH_STATUS_KEY);
+};
+
 // Clear All
 export const clearAllTokens = async () => {
   await deleteAccessToken();
   await deleteRefreshToken();
   await deleteFcmToken();
   await deleteTempAccessToken();
+  await deleteAuthStatus();
 };


### PR DESCRIPTION
## 📝 Work Description

### 인증
- 인증 상태를 `NONE(비로그인)` / `REGISTERING (회원가입 진행 중)` / `AUTHENTICATED (로그인 완료)`로 구분
- 인증 상태가 `REGISTERING` 상태인 경우 회원가입 미완료 시 토큰이 삭제되도록 구현
- 로그아웃/회원 탈퇴 시 `NONE(비로그인)` 상태가 되도록 구현 
- 회원가입 성공 시 인증 상태가 `AUTHENTICATED`로 저장되고, 재접속 시 자동 로그인

### 기타 
- 회원가입 내에서 약관 스크롤 동의 시 ‘모두 동의’ 상태가 반영되는 않는 문제 수정 
- 회원가입 이후 가입 축하 모달이 뜨지 않던 문제 수정 (회원가입 후 `/feed` -> `/leenk`로 이동하게 수정)
- 카카오톡 ID 입력 시 특수 문자 제한 수정
- 회원가입 절차 마지막 단계에서 '시작하자'를 눌렀을 때, 지연 시 `Loading` 컴포넌트 출력
- 자동 로그인 시 accessToken을 중복 인증하는 문제가 있어 수정
- 회원가입 시 정보 입력 단계에서 '지금은 넘어갈래'를 클릭하면 모달이 반복 출력되는 문제 수정

## 📸 Screenshot
<img width="300" alt="image" src="https://github.com/user-attachments/assets/912446a1-8974-4c15-a940-a72cc2b949ec" />

→ 로그인 성공 시 `/feed`로 이동되게 되어 있었어서, `/leenk`로 수정했더니 잘 보입니당,, 굿

## 🚨Issue

- 회원가입 중 프로필 사진 선택 시 가입 버튼 클릭해도 진행되지 않는 이슈는 단순 지연 문제 같아서.. (제가 테스트 했을 땐 한참 기다리면 가긴 했어요. . .) 확인이 더 필요합니다.... ㅠ_ㅠ 

## 📣 To Reviewers

지라에 올라와 있는 회원가입 이슈들 중 간단한 사항들 먼저 후다닥 고쳤습니다!
갤러리 사진 로딩 지연 + 애플 로그인 알 수 없는 오류 발생은 아직 수정 전이라 추후 살펴보아야 할 것 같습니닷 ..  

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 앱 시작 시 일회성 자동 로그인 흐름 추가
  * 신규 회원용 환영 모달 표시 및 전환 플로우 개선
  * 인증 상태(just-signed-up) 영속화 및 플래그 관리 추가

* **버그 수정**
  * KakaoTalk ID 검증에서 점·언더스코어·하이픈 허용
  * 로그아웃 및 계정 삭제 시 인증 상태 초기화 보장

* **개선 사항**
  * 프로필 이미지 업로드(프리사인드 → 공개 URL) 및 제출 로딩 처리 개선
  * 약관 동의 체크 상태 동기화 및 중복 제출 방지 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->