### PR TITLE
Fix: LNK-62-Leenk 회원가입 중 프로필 사진 선택 시 회원가입 미진행 문제 수정 

### DIFF
--- a/app/(page)/leenk.tsx
+++ b/app/(page)/leenk.tsx
@@ -19,6 +19,10 @@ import { SubText, TitleText } from '@/components/OnBoarding';
 import { CongratsIcon } from '@/assets';
 import { useDelayedLoading } from '@/hooks/useDelayedLoading';
 import { useAuthFlagStore } from '@/stores/authFlagStore';
+import { getAuthStatus } from '@/utils/tokenStorage';
+import { useRouter } from 'expo-router';
+import { useToastStore } from '@/stores/toastStore';
+
 import useFirstLaunch from '@/hooks/useFirstLaunch';
 
 const FOOTER_SPACER = 10 * height;
@@ -35,6 +39,8 @@ export default function LeenkPage() {
   const [loading, setLoading] = useState(false);
   const [pullRefreshing, setPullRefreshing] = useState(false);
   const [hasMore, setHasMore] = useState(true);
+  const router = useRouter();
+  const { showToast } = useToastStore();
 
   const didMountRef = useRef(false);
   const listRef = useRef<import('react-native').FlatList<Leenk>>(null);
@@ -47,6 +53,32 @@ export default function LeenkPage() {
   const { justSignedUp, hydrate, clearJustSignedUp } = useAuthFlagStore();
 
   const firstLaunch = useFirstLaunch();
+
+  useFocusEffect(
+    React.useCallback(() => {
+      let cancelled = false;
+
+      const checkAuth = async () => {
+        // 토큰 상태 확인 (로그인 여부)
+        const status = await getAuthStatus();
+        if (cancelled) return;
+
+        // 인증되지 않은 경우
+        if (status !== 'AUTHENTICATED') {
+          showToast('로그인이 필요해', 'error');
+          setTimeout(() => {
+            router.replace('/');
+          }, 1200);
+        }
+      };
+
+      checkAuth();
+
+      return () => {
+        cancelled = true;
+      };
+    }, [showToast, router]),
+  );
 
   useEffect(() => {
     refetch();

--- a/app/(page)/leenk.tsx
+++ b/app/(page)/leenk.tsx
@@ -67,6 +67,7 @@ export default function LeenkPage() {
         if (status !== 'AUTHENTICATED') {
           showToast('로그인이 필요해', 'error');
           setTimeout(() => {
+            if (cancelled) return;
             router.replace('/');
           }, 1200);
         }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -30,7 +30,7 @@ export default function IndexPage() {
       try {
         const token = await getAccessToken();
         if (token && !isTokenExpired(token)) {
-          router.replace('/(page)/feed');
+          router.replace('/(page)/leenk');
           return;
         }
       } catch (error) {

--- a/app/signup/profile.tsx
+++ b/app/signup/profile.tsx
@@ -210,11 +210,10 @@ export default function ProfilePage() {
         await withTimeout(registerFcmToken(), 3000);
       } catch (e) {
         console.warn('[handleSkip] registerFcmToken failed or timeout', e);
-        showToast('[handleNext] FCM 등록 실패', 'error'); // 테스트 이후 삭제
+        showToast('[handleSkip] FCM 등록 실패', 'error'); // 테스트 이후 삭제
       }
 
       await saveAuthStatus('AUTHENTICATED');
-      await setJustSignedUp(true);
       await useAuthFlagStore.getState().setJustSignedUp();
 
       router.replace('/(page)/leenk');

--- a/app/signup/profile.tsx
+++ b/app/signup/profile.tsx
@@ -87,6 +87,16 @@ export default function ProfilePage() {
 
   const ACCESSORY_ID = 'profile-accessory';
 
+  // 타임 아웃 처리
+  const withTimeout = <T,>(promise: Promise<T>, ms = 3000) => {
+    return Promise.race([
+      promise,
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('FCM_TIMEOUT')), ms),
+      ),
+    ]);
+  };
+
   // ----- 저장 -----
   const saveProfile = async () => {
     const payload: UpdateProfilePayload = {};
@@ -96,6 +106,8 @@ export default function ProfilePage() {
     if (birthday) payload.birthday = birthday;
 
     if (profileImage) {
+      showToast('프로필 이미지 업로드 시도', 'success'); // 테스트 이후 삭제
+
       const fileName = `profile_${Date.now()}.jpg`;
       try {
         const presignedUrls = await getPresignedUrl(fileName, 'PROFILE');
@@ -112,6 +124,8 @@ export default function ProfilePage() {
         } catch {
           payload.profileImage = mediaUrl.split('?')[0];
         }
+
+        showToast('프로필 이미지 업로드에 성공했어.', 'success'); // 테스트 이후 삭제
       } catch (error) {
         console.error('[saveProfile] 프로필 이미지 업로드 실패:', error);
         showToast('프로필 이미지 업로드에 실패했어.', 'error');
@@ -121,6 +135,7 @@ export default function ProfilePage() {
 
     try {
       await updateUserProfile(payload);
+      showToast('프로필 저장에 성공했어.', 'success'); // 테스트 이후 삭제
     } catch (error) {
       console.error('[saveProfile] 프로필 저장 실패:', error);
       showToast('프로필 저장에 실패했어.', 'error');
@@ -145,11 +160,25 @@ export default function ProfilePage() {
         setIsSubmitting(true);
 
         await saveProfile();
-        await registerFcmToken();
+
+        try {
+          await withTimeout(registerFcmToken(), 3000);
+        } catch (e) {
+          console.warn('[handleNext] registerFcmToken failed or timeout', e);
+          showToast('[handleNext] FCM 등록 실패', 'error'); // 테스트 이후 삭제
+        }
+
         await saveAuthStatus('AUTHENTICATED');
         await useAuthFlagStore.getState().setJustSignedUp();
 
         router.replace('/(page)/leenk');
+
+        // iOS replace 실패 대비
+        setTimeout(() => {
+          if (mountedRef.current) {
+            setIsSubmitting(false);
+          }
+        }, 500);
       } catch (e) {
         console.error('[handleNext] 실패:', e);
       } finally {
@@ -167,6 +196,8 @@ export default function ProfilePage() {
   };
 
   const handleSkip = async () => {
+    console.log('[handleSkip] skip pressed');
+
     if (isSubmitting) return;
 
     setSkipModalVisible(false);
@@ -174,7 +205,14 @@ export default function ProfilePage() {
       setIsSubmitting(true);
 
       await saveProfile();
-      await registerFcmToken();
+
+      try {
+        await withTimeout(registerFcmToken(), 3000);
+      } catch (e) {
+        console.warn('[handleSkip] registerFcmToken failed or timeout', e);
+        showToast('[handleNext] FCM 등록 실패', 'error'); // 테스트 이후 삭제
+      }
+
       await saveAuthStatus('AUTHENTICATED');
       await setJustSignedUp(true);
       await useAuthFlagStore.getState().setJustSignedUp();

--- a/app/signup/profile.tsx
+++ b/app/signup/profile.tsx
@@ -58,6 +58,7 @@ export default function ProfilePage() {
   const randomMbti = useRandomMbti(2000);
   const insets = useSafeAreaInsets();
   const { showToast } = useToastStore();
+  const [isKakaoConfirmed, setIsKakaoConfirmed] = useState(false);
 
   const mountedRef = useRef(true);
   useEffect(() => {
@@ -214,6 +215,7 @@ export default function ProfilePage() {
       }
 
       await saveAuthStatus('AUTHENTICATED');
+      await setJustSignedUp(true);
       await useAuthFlagStore.getState().setJustSignedUp();
 
       router.replace('/(page)/leenk');
@@ -258,7 +260,8 @@ export default function ProfilePage() {
           (step === 'id' &&
             (kakaoTalkId.trim() === '' ||
               kakaoTalkId.length < 4 ||
-              kakaoTalkId.length > 20)) ||
+              kakaoTalkId.length > 20 ||
+              !isKakaoConfirmed)) ||
           (step === 'introduction' && introduction.trim() === '') ||
           (step === 'mbti' && (mbti.trim() === '' || mbti.length !== 4))
         }
@@ -325,9 +328,10 @@ export default function ProfilePage() {
             <Input
               title="카카오톡 ID를 입력해줘"
               value={kakaoTalkId}
-              onChangeText={(text) =>
-                setkakaoTalkId(text.replace(/[^a-zA-Z0-9._-]/g, ''))
-              }
+              onChangeText={(text) => {
+                setkakaoTalkId(text.replace(/[^a-zA-Z0-9._-]/g, ''));
+                setIsKakaoConfirmed(false);
+              }}
               placeholder="모임원들과의 연락을 위해 필요해"
               subMessage="ID는 카카오톡 > 친구 추가 > 카카오톡 ID 에서 볼 수 있어."
               accessoryID={isIOS ? ACCESSORY_ID : undefined}
@@ -339,8 +343,12 @@ export default function ProfilePage() {
             />
             <PopupModal
               isOpen={kakaoModalVisible}
-              onLeftBtn={() => setKakaoModalVisible(false)}
+              onLeftBtn={() => {
+                setIsKakaoConfirmed(false);
+                setKakaoModalVisible(false);
+              }}
               onRightBtn={() => {
+                setIsKakaoConfirmed(true);
                 setKakaoModalVisible(false);
                 setTimeout(() => setStep('photo'), 100);
               }}

--- a/app/signup/profile.tsx
+++ b/app/signup/profile.tsx
@@ -13,7 +13,7 @@ import { CustomButton, Header, Input, Textarea } from '@/components';
 import colors from '@/theme/color';
 import { fontSize, height, width, fonts } from '@/theme/globalStyles';
 // import { Image } from 'expo-image';
-import { Image } from 'react-native';
+// import { Image } from 'react-native';
 
 import { DefaultProfileImage } from '@/assets';
 import { useRouter } from 'expo-router';
@@ -22,7 +22,7 @@ import {
   UpdateProfilePayload,
   updateUserProfile,
 } from '@/api/login/patchUsersInfo.api';
-import { getPresignedUrl, uploadImageToS3 } from '@/api/file/s3Upload';
+// import { getPresignedUrl, uploadImageToS3 } from '@/api/file/s3Upload';
 import useRandomMbti from '@/hooks/useRandomMbti';
 import ProfileTitleText from '@/components/signup/ProfileTitleText';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -48,7 +48,7 @@ export default function ProfilePage() {
     setBirthday,
     mbti,
     setMbti,
-    profileImage,
+    // profileImage,
   } = useProfileStore();
 
   const [kakaoModalVisible, setKakaoModalVisible] = useState(false);
@@ -106,37 +106,34 @@ export default function ProfilePage() {
     if (mbti) payload.mbti = mbti;
     if (birthday) payload.birthday = birthday;
 
-    if (profileImage) {
-      showToast('프로필 이미지 업로드 시도', 'success'); // 테스트 이후 삭제
+    // if (profileImage) {
 
-      const fileName = `profile_${Date.now()}.jpg`;
-      try {
-        const presignedUrls = await getPresignedUrl(fileName, 'PROFILE');
-        if (!presignedUrls || presignedUrls.length === 0) {
-          throw new Error('presigned URL 생성에 실패했습니다.');
-        }
-        const mediaUrl = presignedUrls[0].mediaUrl;
+    //   const fileName = `profile_${Date.now()}.jpg`;
+    //   try {
+    //     const presignedUrls = await getPresignedUrl(fileName, 'PROFILE');
+    //     if (!presignedUrls || presignedUrls.length === 0) {
+    //       throw new Error('presigned URL 생성에 실패했습니다.');
+    //     }
+    //     const mediaUrl = presignedUrls[0].mediaUrl;
 
-        await uploadImageToS3(mediaUrl, profileImage);
+    //     await uploadImageToS3(mediaUrl, profileImage);
 
-        try {
-          const url = new URL(mediaUrl);
-          payload.profileImage = `${url.protocol}//${url.host}${url.pathname}`;
-        } catch {
-          payload.profileImage = mediaUrl.split('?')[0];
-        }
+    //     try {
+    //       const url = new URL(mediaUrl);
+    //       payload.profileImage = `${url.protocol}//${url.host}${url.pathname}`;
+    //     } catch {
+    //       payload.profileImage = mediaUrl.split('?')[0];
+    //     }
 
-        showToast('프로필 이미지 업로드에 성공했어.', 'success'); // 테스트 이후 삭제
-      } catch (error) {
-        console.error('[saveProfile] 프로필 이미지 업로드 실패:', error);
-        showToast('프로필 이미지 업로드에 실패했어.', 'error');
-        throw error;
-      }
-    }
+    //   } catch (error) {
+    //     console.error('[saveProfile] 프로필 이미지 업로드 실패:', error);
+    //     showToast('프로필 이미지 업로드에 실패했어.', 'error');
+    //     throw error;
+    //   }
+    // }
 
     try {
       await updateUserProfile(payload);
-      showToast('프로필 저장에 성공했어.', 'success'); // 테스트 이후 삭제
     } catch (error) {
       console.error('[saveProfile] 프로필 저장 실패:', error);
       showToast('프로필 저장에 실패했어.', 'error');
@@ -150,8 +147,8 @@ export default function ProfilePage() {
 
     if (step === 'id') {
       setKakaoModalVisible(true);
-    } else if (step === 'photo') {
-      setStep('introduction');
+      // } else if (step === 'photo') {
+      //   setStep('introduction');
     } else if (step === 'introduction') {
       setStep('birthday');
     } else if (step === 'birthday') {
@@ -166,7 +163,6 @@ export default function ProfilePage() {
           await withTimeout(registerFcmToken(), 3000);
         } catch (e) {
           console.warn('[handleNext] registerFcmToken failed or timeout', e);
-          showToast('[handleNext] FCM 등록 실패', 'error'); // 테스트 이후 삭제
         }
 
         await saveAuthStatus('AUTHENTICATED');
@@ -189,16 +185,15 @@ export default function ProfilePage() {
   };
 
   const handlePrevStep = () => {
-    if (step === 'photo') setStep('id');
-    else if (step === 'introduction') setStep('photo');
+    if (step === 'introduction') setStep('id');
+    // if (step === 'photo') setStep('id');
+    // else if (step === 'introduction') setStep('photo');
     else if (step === 'birthday') setStep('introduction');
     else if (step === 'mbti') setStep('birthday');
     else router.back();
   };
 
   const handleSkip = async () => {
-    console.log('[handleSkip] skip pressed');
-
     if (isSubmitting) return;
 
     setSkipModalVisible(false);
@@ -211,7 +206,6 @@ export default function ProfilePage() {
         await withTimeout(registerFcmToken(), 3000);
       } catch (e) {
         console.warn('[handleSkip] registerFcmToken failed or timeout', e);
-        showToast('[handleSkip] FCM 등록 실패', 'error'); // 테스트 이후 삭제
       }
 
       await saveAuthStatus('AUTHENTICATED');
@@ -226,9 +220,9 @@ export default function ProfilePage() {
     }
   };
 
-  const handleImagePick = () => {
-    router.push('/signup/select-image');
-  };
+  // const handleImagePick = () => {
+  //   router.push('/signup/select-image');
+  // };
 
   // ----- 버튼 묶음 -----
   const NormalButtons = () => (
@@ -350,7 +344,8 @@ export default function ProfilePage() {
               onRightBtn={() => {
                 setIsKakaoConfirmed(true);
                 setKakaoModalVisible(false);
-                setTimeout(() => setStep('photo'), 100);
+                // setTimeout(() => setStep('photo'), 100);
+                setTimeout(() => setStep('introduction'), 100);
               }}
               mainText={kakaoTalkId}
               subText="카톡 아이디가 맞는지 확인해 줘."
@@ -405,7 +400,7 @@ export default function ProfilePage() {
           />
         )}
 
-        {step === 'photo' && (
+        {/* {step === 'photo' && (
           <>
             <StyledSubText>프로필 사진을 설정해줘</StyledSubText>
             <ImagePreview>
@@ -429,7 +424,7 @@ export default function ProfilePage() {
               프로필 사진 선택하기
             </CustomButton>
           </>
-        )}
+        )} */}
       </Scroll>
 
       {/* ===== 하단 액션 영역 ===== */}

--- a/app/signup/verify.tsx
+++ b/app/signup/verify.tsx
@@ -20,11 +20,15 @@ export default function VerifyPage() {
   const { showToast } = useToastStore();
 
   const handleCancel = async () => {
-    await clearAllTokens();
-    await deleteAuthStatus();
+    try {
+      await clearAllTokens();
+      await deleteAuthStatus();
+    } catch (e) {
+      if (__DEV__) console.error('토큰 정리 실패:', e);
+    }
     reset();
-    router.replace('/');
     showToast('관리자에게 문의해주세요.', 'error');
+    router.replace('/');
   };
 
   const handleRight = () => {

--- a/app/signup/verify.tsx
+++ b/app/signup/verify.tsx
@@ -9,15 +9,18 @@ import { useProfileStore } from '@/stores/profileStore';
 import { Position } from '@/constants/Position';
 import { useBlockBackHandler } from '@/hooks/useBlockBackHandler';
 import { useToastStore } from '@/stores/toastStore';
+import { deleteAuthStatus } from '@/utils/tokenStorage';
 
 export default function VerifyPage() {
   useBlockBackHandler({ block: true });
 
   const router = useRouter();
-  const { name, cardinal, position } = useProfileStore();
+  const { name, cardinal, position, reset } = useProfileStore();
   const { showToast } = useToastStore();
 
-  const handleCancel = () => {
+  const handleCancel = async () => {
+    await deleteAuthStatus();
+    reset();
     router.replace('/');
     showToast('관리자에게 문의해주세요.', 'error');
   };

--- a/app/signup/verify.tsx
+++ b/app/signup/verify.tsx
@@ -9,7 +9,6 @@ import { useProfileStore } from '@/stores/profileStore';
 import { Position } from '@/constants/Position';
 import { useBlockBackHandler } from '@/hooks/useBlockBackHandler';
 import { useToastStore } from '@/stores/toastStore';
-import { deleteAuthStatus } from '@/utils/tokenStorage';
 import { clearAllTokens } from '@/utils/tokenStorage';
 
 export default function VerifyPage() {
@@ -22,7 +21,6 @@ export default function VerifyPage() {
   const handleCancel = async () => {
     try {
       await clearAllTokens();
-      await deleteAuthStatus();
     } catch (e) {
       if (__DEV__) console.error('토큰 정리 실패:', e);
     }

--- a/app/signup/verify.tsx
+++ b/app/signup/verify.tsx
@@ -10,6 +10,7 @@ import { Position } from '@/constants/Position';
 import { useBlockBackHandler } from '@/hooks/useBlockBackHandler';
 import { useToastStore } from '@/stores/toastStore';
 import { deleteAuthStatus } from '@/utils/tokenStorage';
+import { clearAllTokens } from '@/utils/tokenStorage';
 
 export default function VerifyPage() {
   useBlockBackHandler({ block: true });
@@ -19,6 +20,7 @@ export default function VerifyPage() {
   const { showToast } = useToastStore();
 
   const handleCancel = async () => {
+    await clearAllTokens();
     await deleteAuthStatus();
     reset();
     router.replace('/');

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -81,9 +81,14 @@ export default function LandingPage() {
         return;
       }
 
+      useProfileStore.getState().reset?.();
+
       await saveAccessToken(data.accessToken);
       await saveRefreshToken(data.refreshToken);
       await saveAuthStatus('REGISTERING');
+
+      // iOS Keychain 반영 대기
+      await new Promise((r) => setTimeout(r, 150));
 
       setName(data.name);
       setPosition(data.position);


### PR DESCRIPTION
## 📝 Work Description

- FCM 등록 요청 타임아웃 처리
- iOS 환경에서 replace 실패 시 무한 로딩 방지 로직 추가
- 위드 계정 미선택 시 토큰 상태 및 토큰 삭제하도록 변경
- 토큰 미인증 상태에서 leenk 페이지 접근 시 `/`로 리다이렉트되게 수정

## 📸 Screenshot
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img width="300" src="이미지 주소" /> -->

<img width="700" alt="image" src="https://github.com/user-attachments/assets/e15ca5cf-8bfb-4d43-a22b-4a2e1b0934b2" />

회원가입 플로우 수정하고 테스트 해보니 안드 환경에선 로딩 없이 잘 되긴 했습니다....
ㅠㅠ 잘 되길,,,

## 🚨Issue

## 📣 To Reviewers

QA + 문제 파악을 위해 토스트 메시지 몇 줄을 임시로 추가했습니다!
문제 파악되면 바로 삭제할 예정입니당 

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 특정 페이지 포커스 시 클라이언트 인증 검사 후 미인증이면 경고 및 홈 리다이렉트
  * 로그인 후 기본 이동 대상이 피드에서 해당 페이지로 변경

* **버그 수정**
  * FCM 등록에 3초 타임아웃 적용 및 타임아웃/실패 시 경고 표시
  * 네비게이션 후 iOS 제출 상태 안정화를 위한 지연 리셋
  * 회원가입 취소 시 모든 토큰 삭제 및 프로필 상태 초기화(비동기 처리)

* **개선사항**
  * 프로필 사진 업로드 및 사진 단계 제거/숨김
  * 카카오 ID 확인 흐름 강화(입력 변경 시 재확인, 확인 필수화로 하단 버튼 활성화 조건 업데이트)
  * 소셜 가입 흐름에서 프로필 초기화 및 Keychain 반영 대기(약 150ms) 적용

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->