### PR TITLE
[Fix] LNK-77-Leenk : 온보딩 과정 및 서버 무한 로딩 문제 수정

### DIFF
--- a/app/signup/profile.tsx
+++ b/app/signup/profile.tsx
@@ -38,24 +38,24 @@ import dayjs from 'dayjs';
 
 export default function ProfilePage() {
   const {
-    step,
-    setStep,
+    // step,
+    // setStep,
     kakaoTalkId,
     setkakaoTalkId,
-    introduction,
-    setintroduction,
-    birthday,
-    setBirthday,
-    mbti,
-    setMbti,
+    // introduction,
+    // setintroduction,
+    // birthday,
+    // setBirthday,
+    // mbti,
+    // setMbti,
     // profileImage,
   } = useProfileStore();
 
   const [kakaoModalVisible, setKakaoModalVisible] = useState(false);
-  const [skipModalVisible, setSkipModalVisible] = useState(false);
+  // const [skipModalVisible, setSkipModalVisible] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const router = useRouter();
-  const randomMbti = useRandomMbti(2000);
+  // const randomMbti = useRandomMbti(2000);
   const insets = useSafeAreaInsets();
   const { showToast } = useToastStore();
   const [isKakaoConfirmed, setIsKakaoConfirmed] = useState(false);
@@ -102,9 +102,9 @@ export default function ProfilePage() {
   const saveProfile = async () => {
     const payload: UpdateProfilePayload = {};
     if (kakaoTalkId) payload.kakaoTalkId = kakaoTalkId;
-    if (introduction) payload.introduction = introduction;
-    if (mbti) payload.mbti = mbti;
-    if (birthday) payload.birthday = birthday;
+    // if (introduction) payload.introduction = introduction;
+    // if (mbti) payload.mbti = mbti;
+    // if (birthday) payload.birthday = birthday;
 
     // if (profileImage) {
 
@@ -144,59 +144,54 @@ export default function ProfilePage() {
   // ----- 다음 -----
   const handleNext = async () => {
     if (isSubmitting) return;
+    setKakaoModalVisible(true);
 
-    if (step === 'id') {
-      setKakaoModalVisible(true);
-      // } else if (step === 'photo') {
-      //   setStep('introduction');
-    } else if (step === 'introduction') {
-      setStep('birthday');
-    } else if (step === 'birthday') {
-      setStep('mbti');
-    } else {
-      try {
-        setIsSubmitting(true);
-
-        await saveProfile();
-
-        try {
-          await withTimeout(registerFcmToken(), 3000);
-        } catch (e) {
-          console.warn('[handleNext] registerFcmToken failed or timeout', e);
-        }
-
-        await saveAuthStatus('AUTHENTICATED');
-        await useAuthFlagStore.getState().setJustSignedUp();
-
-        router.replace('/(page)/leenk');
-
-        // iOS replace 실패 대비
-        setTimeout(() => {
-          if (mountedRef.current) {
-            setIsSubmitting(false);
-          }
-        }, 500);
-      } catch (e) {
-        console.error('[handleNext] 실패:', e);
-      } finally {
-        if (mountedRef.current) setIsSubmitting(false);
-      }
-    }
+    // if (step === 'id') {
+    //   setKakaoModalVisible(true);
+    //   // } else if (step === 'photo') {
+    //   //   setStep('introduction');
+    // } else if (step === 'introduction') {
+    //   setStep('birthday');
+    // } else if (step === 'birthday') {
+    //   setStep('mbti');
+    // } else {
+    //   try {
+    //     setIsSubmitting(true);
+    //
+    //     await saveProfile();
+    //
+    //     try {
+    //       await withTimeout(registerFcmToken(), 3000);
+    //     } catch (e) {
+    //       console.warn('[handleNext] registerFcmToken failed or timeout', e);
+    //     }
+    //
+    //     await saveAuthStatus('AUTHENTICATED');
+    //     await useAuthFlagStore.getState().setJustSignedUp();
+    //
+    //     router.replace('/(page)/leenk');
+    //
+    //     // iOS replace 실패 대비
+    //     setTimeout(() => {
+    //       if (mountedRef.current) {
+    //         setIsSubmitting(false);
+    //       }
+    //     }, 500);
+    //   } catch (e) {
+    //     console.error('[handleNext] 실패:', e);
+    //   } finally {
+    //     if (mountedRef.current) setIsSubmitting(false);
+    //   }
+    // }
   };
 
-  const handlePrevStep = () => {
-    if (step === 'introduction') setStep('id');
-    // if (step === 'photo') setStep('id');
-    // else if (step === 'introduction') setStep('photo');
-    else if (step === 'birthday') setStep('introduction');
-    else if (step === 'mbti') setStep('birthday');
-    else router.back();
-  };
-
-  const handleSkip = async () => {
+  // 카카오톡 ID 확인 후 회원가입 완료
+  const handleConfirmAndComplete = async () => {
     if (isSubmitting) return;
 
-    setSkipModalVisible(false);
+    setIsKakaoConfirmed(true);
+    setKakaoModalVisible(false);
+
     try {
       setIsSubmitting(true);
 
@@ -205,7 +200,7 @@ export default function ProfilePage() {
       try {
         await withTimeout(registerFcmToken(), 3000);
       } catch (e) {
-        console.warn('[handleSkip] registerFcmToken failed or timeout', e);
+        console.warn('[handleNext] registerFcmToken failed or timeout', e);
       }
 
       await saveAuthStatus('AUTHENTICATED');
@@ -213,12 +208,55 @@ export default function ProfilePage() {
       await useAuthFlagStore.getState().setJustSignedUp();
 
       router.replace('/(page)/leenk');
-    } catch (error) {
-      console.error('[handleSkip] 실패:', error);
+
+      setTimeout(() => {
+        if (mountedRef.current) {
+          setIsSubmitting(false);
+        }
+      }, 500);
+    } catch (e) {
+      console.error('[handleNext] 실패:', e);
     } finally {
       if (mountedRef.current) setIsSubmitting(false);
     }
   };
+
+  const handlePrevStep = () => {
+    // if (step === 'introduction') setStep('id');
+    // // if (step === 'photo') setStep('id');
+    // // else if (step === 'introduction') setStep('photo');
+    // else if (step === 'birthday') setStep('introduction');
+    // else if (step === 'mbti') setStep('birthday');
+    // else router.back();
+    router.back();
+  };
+
+  // const handleSkip = async () => {
+  //   if (isSubmitting) return;
+  //
+  //   setSkipModalVisible(false);
+  //   try {
+  //     setIsSubmitting(true);
+  //
+  //     await saveProfile();
+  //
+  //     try {
+  //       await withTimeout(registerFcmToken(), 3000);
+  //     } catch (e) {
+  //       console.warn('[handleSkip] registerFcmToken failed or timeout', e);
+  //     }
+  //
+  //     await saveAuthStatus('AUTHENTICATED');
+  //     await setJustSignedUp(true);
+  //     await useAuthFlagStore.getState().setJustSignedUp();
+  //
+  //     router.replace('/(page)/leenk');
+  //   } catch (error) {
+  //     console.error('[handleSkip] 실패:', error);
+  //   } finally {
+  //     if (mountedRef.current) setIsSubmitting(false);
+  //   }
+  // };
 
   // const handleImagePick = () => {
   //   router.push('/signup/select-image');
@@ -227,7 +265,7 @@ export default function ProfilePage() {
   // ----- 버튼 묶음 -----
   const NormalButtons = () => (
     <View style={{ width: '100%' }}>
-      {step !== 'id' && (
+      {/* {step !== 'id' && (
         <>
           <CustomButton
             variant="text"
@@ -241,7 +279,7 @@ export default function ProfilePage() {
             지금은 넘어갈래
           </CustomButton>
         </>
-      )}
+      )} */}
 
       <CustomButton
         variant="primary"
@@ -251,16 +289,21 @@ export default function ProfilePage() {
         size="lg"
         style={{ marginBottom: 10 * height }}
         disabled={
-          (step === 'id' &&
-            (kakaoTalkId.trim() === '' ||
-              kakaoTalkId.length < 4 ||
-              kakaoTalkId.length > 20 ||
-              !isKakaoConfirmed)) ||
-          (step === 'introduction' && introduction.trim() === '') ||
-          (step === 'mbti' && (mbti.trim() === '' || mbti.length !== 4))
+          kakaoTalkId.trim() === '' ||
+          kakaoTalkId.length < 4 ||
+          kakaoTalkId.length > 20 ||
+          !isKakaoConfirmed
+          // (step === 'id' &&
+          //   (kakaoTalkId.trim() === '' ||
+          //     kakaoTalkId.length < 4 ||
+          //     kakaoTalkId.length > 20 ||
+          //     !isKakaoConfirmed)) ||
+          // (step === 'introduction' && introduction.trim() === '') ||
+          // (step === 'mbti' && (mbti.trim() === '' || mbti.length !== 4))
         }
       >
-        {step === 'mbti' ? '시작하자' : '다음으로'}
+        {/* {step === 'mbti' ? '시작하자' : '다음으로'} */}
+        다음으로
       </CustomButton>
     </View>
   );
@@ -276,15 +319,19 @@ export default function ProfilePage() {
         size="lg"
         style={{ marginBottom: 0 }}
         disabled={
-          (step === 'id' &&
-            (kakaoTalkId.trim() === '' ||
-              kakaoTalkId.length < 4 ||
-              kakaoTalkId.length > 20)) ||
-          (step === 'introduction' && introduction.trim() === '') ||
-          (step === 'mbti' && (mbti.trim() === '' || mbti.length !== 4))
+          kakaoTalkId.trim() === '' ||
+          kakaoTalkId.length < 4 ||
+          kakaoTalkId.length > 20
+          // (step === 'id' &&
+          //   (kakaoTalkId.trim() === '' ||
+          //     kakaoTalkId.length < 4 ||
+          //     kakaoTalkId.length > 20)) ||
+          // (step === 'introduction' && introduction.trim() === '') ||
+          // (step === 'mbti' && (mbti.trim() === '' || mbti.length !== 4))
         }
       >
-        {step === 'mbti' ? '시작하자' : '다음으로'}
+        {/* {step === 'mbti' ? '시작하자' : '다음으로'} */}
+        다음으로
       </CustomButton>
     </View>
   );
@@ -297,7 +344,7 @@ export default function ProfilePage() {
 
   return (
     <Container>
-      <PopupModal
+      {/* <PopupModal
         isOpen={skipModalVisible}
         onLeftBtn={() => setSkipModalVisible(false)}
         onRightBtn={handleSkip}
@@ -306,7 +353,7 @@ export default function ProfilePage() {
         leftBtnText="취소"
         rightBtnText="나중에 할래"
         isCancel={false}
-      />
+      /> */}
       <Scroll
         automaticallyAdjustKeyboardInsets={false}
         keyboardDismissMode="interactive"
@@ -317,7 +364,7 @@ export default function ProfilePage() {
         <Header signUpBackPress={handlePrevStep} />
         <ProfileTitleText>프로필을 만들어보자</ProfileTitleText>
 
-        {step === 'id' && (
+        {/* {step === 'id' && ( */}
           <>
             <Input
               title="카카오톡 ID를 입력해줘"
@@ -341,12 +388,7 @@ export default function ProfilePage() {
                 setIsKakaoConfirmed(false);
                 setKakaoModalVisible(false);
               }}
-              onRightBtn={() => {
-                setIsKakaoConfirmed(true);
-                setKakaoModalVisible(false);
-                // setTimeout(() => setStep('photo'), 100);
-                setTimeout(() => setStep('introduction'), 100);
-              }}
+              onRightBtn={handleConfirmAndComplete}
               mainText={kakaoTalkId}
               subText="카톡 아이디가 맞는지 확인해 줘."
               leftBtnText="아니야"
@@ -354,9 +396,9 @@ export default function ProfilePage() {
               isCancel={false}
             />
           </>
-        )}
+        {/* )} */}
 
-        {step === 'introduction' && (
+        {/* {step === 'introduction' && (
           <Textarea
             value={introduction}
             onChangeText={setintroduction}
@@ -366,9 +408,9 @@ export default function ProfilePage() {
             minHeight={1}
             accessoryID={isIOS ? ACCESSORY_ID : undefined}
           />
-        )}
+        )} */}
 
-        {step === 'birthday' && (
+        {/* {step === 'birthday' && (
           <>
             <StyledSubText>생일을 알려줘</StyledSubText>
             <CalendarButton
@@ -384,9 +426,9 @@ export default function ProfilePage() {
               placeholder="생일 축하를 받을 수 있어"
             />
           </>
-        )}
+        )} */}
 
-        {step === 'mbti' && (
+        {/* {step === 'mbti' && (
           <Input
             title="MBTI를 입력해줘"
             value={mbti}
@@ -398,7 +440,7 @@ export default function ProfilePage() {
             maxLength={4}
             accessoryID={isIOS ? ACCESSORY_ID : undefined}
           />
-        )}
+        )} */}
 
         {/* {step === 'photo' && (
           <>

--- a/app/signup/profile.tsx
+++ b/app/signup/profile.tsx
@@ -290,8 +290,7 @@ export default function ProfilePage() {
         disabled={
           kakaoTalkId.trim() === '' ||
           kakaoTalkId.length < 4 ||
-          kakaoTalkId.length > 20 ||
-          !isKakaoConfirmed
+          kakaoTalkId.length > 20
           // (step === 'id' &&
           //   (kakaoTalkId.trim() === '' ||
           //     kakaoTalkId.length < 4 ||

--- a/app/signup/profile.tsx
+++ b/app/signup/profile.tsx
@@ -31,7 +31,7 @@ import { useToastStore } from '@/stores/toastStore';
 import { registerFcmToken } from '@/components/LandingPage';
 import { saveAuthStatus } from '@/utils/tokenStorage';
 import CalendarButton from '@/components/leenk/CalendarButton';
-import { setJustSignedUp } from '@/utils/authFlagStorage';
+// import { setJustSignedUp } from '@/utils/authFlagStorage';
 import { useAuthFlagStore } from '@/stores/authFlagStore';
 import { Loading } from '@/components';
 import dayjs from 'dayjs';
@@ -204,7 +204,6 @@ export default function ProfilePage() {
       }
 
       await saveAuthStatus('AUTHENTICATED');
-      await setJustSignedUp(true);
       await useAuthFlagStore.getState().setJustSignedUp();
 
       router.replace('/(page)/leenk');

--- a/app/signup/terms.tsx
+++ b/app/signup/terms.tsx
@@ -20,10 +20,6 @@ import { infoTerm, serviceTerm } from '@/constants/termsText';
 import LinearGradient from 'react-native-linear-gradient';
 import { updateUserAgreement } from '@/api/users/patchUserEachInfo.api';
 import { useToastStore } from '@/stores/toastStore';
-import { registerFcmToken } from '@/components/LandingPage';
-import { saveAuthStatus } from '@/utils/tokenStorage';
-import { setJustSignedUp } from '@/utils/authFlagStorage';
-import { useAuthFlagStore } from '@/stores/authFlagStore';
 
 export default function TermsPage() {
   const [allCheck, setAllCheck] = useState(false);
@@ -56,43 +52,14 @@ export default function TermsPage() {
     setAllCheck(serviceCheck && next);
   };
 
-  // 타임 아웃 처리
-  const withTimeout = <T,>(promise: Promise<T>, ms = 3000) => {
-    return Promise.race([
-      promise,
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('FCM_TIMEOUT')), ms),
-      ),
-    ]);
-  };
-
   const handleNext = async () => {
     try {
-      // 1. 약관 동의 저장
       await updateUserAgreement({
         termsService: serviceCheck,
         privacyPolicy: infoCheck,
       });
 
-      // 2. FCM 토큰 등록
-      try {
-        await withTimeout(registerFcmToken(), 3000);
-      } catch (e) {
-        console.warn('[handleNext] registerFcmToken failed or timeout', e);
-      }
-
-      // 3. 인증 상태 확정
-      try {
-        await saveAuthStatus('AUTHENTICATED');
-        await setJustSignedUp(true);
-        await useAuthFlagStore.getState().setJustSignedUp();
-      } catch (e) {
-        console.error('[handleNext] auth state persistence failed', e);
-      }
-
-      // 4. 홈으로
-      // router.replace('/signup/verify');
-      router.replace('/(page)/leenk');
+      router.replace('/signup/profile');
     } catch (error) {
       showToast('약관 동의에 실패했어.', 'error');
     }

--- a/hooks/useUserInfo.ts
+++ b/hooks/useUserInfo.ts
@@ -1,5 +1,5 @@
 import { getUsersInfo } from '@/api/users/getUsersInfo.api';
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { getRefreshToken, clearAllTokens } from '@/utils/tokenStorage';
 import { useRouter } from 'expo-router';
 import axios from 'axios';
@@ -24,13 +24,16 @@ export const useUserInfo = () => {
   const [error, setError] = useState<Error | null>(null);
   const router = useRouter();
 
+  const loadingRef = useRef(false);
+
   const fetchUserInfo = useCallback(async () => {
-    if (loading) return;
+    if (loadingRef.current) return;
 
     const refreshToken = await getRefreshToken();
     if (!refreshToken) return;
 
     try {
+      loadingRef.current = true;
       setLoading(true);
       setError(null);
       const data = await getUsersInfo();
@@ -46,9 +49,10 @@ export const useUserInfo = () => {
         router.replace('/');
       }
     } finally {
+      loadingRef.current = false;
       setLoading(false);
     }
-  }, [loading, router]);
+  }, [router]);
 
   return { userInfo, loading, error, refetch: fetchUserInfo };
 };

--- a/hooks/useUserInfo.ts
+++ b/hooks/useUserInfo.ts
@@ -28,12 +28,15 @@ export const useUserInfo = () => {
 
   const fetchUserInfo = useCallback(async () => {
     if (loadingRef.current) return;
+    loadingRef.current = true;
 
     const refreshToken = await getRefreshToken();
-    if (!refreshToken) return;
+    if (!refreshToken) {
+      loadingRef.current = false;
+      return;
+    }
 
     try {
-      loadingRef.current = true;
       setLoading(true);
       setError(null);
       const data = await getUsersInfo();


### PR DESCRIPTION
- closed #77

## 📝 Work Description

  - 약관 동의 후 카카오톡 ID 입력 단계를 추가하고, 나머지 프로필 단계(자기소개, 생일, MBTI)는 주석 처리
  - useUserInfo 훅의 useCallback 의존성에서 loading state를 제거하여 생일 페이지(extra.tsx)에서 birthday api 무한 요청 버그 수정

### 수정된 회원가입 플로우

  - 약관 동의 → 카카오톡 ID 확인 후 프로필 저장 → FCM 등록 → 인증 상태 확정 → 홈 이동으로 회원가입 완료 플로우 간소화

## 📸 Screenshot
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img width="300" src="이미지 주소" /> -->

## 🚨Issue

## 📣 To Reviewers

온보딩 잘 뜨는지 + 생일 페이지 테스트가 필요합니다 ㅜ  ㅜ....
수정은 빠르게 할 수 잇는 내용들이라 후다닥 해뒀는데 잘 됐으면 좋겠네용... 🙏🙏🙏

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 회원가입 프로필 설정 흐름을 간소화하여 단계 기반 입력 대신 카카오 확인 중심으로 완료하도록 변경했습니다.
  * 약관 동의 후 다음 이동 경로를 프로필로 통일하고, 불필요한 백그라운드 등록 시도를 제거했습니다.
  * 카카오 확인 모달의 완료 동작을 통합해 가입 완료 처리(저장·인증 상태 갱신·이동)를 일괄 실행합니다.
  * 사용자 정보 조회 시 중복 요청을 방지하는 동시성 처리를 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->