### PR TITLE
[Fix] 특정 페이지에서만 헤더가 밀리는 현상 해결

### DIFF
--- a/app/(post)/feed/link-members/index.tsx
+++ b/app/(post)/feed/link-members/index.tsx
@@ -128,7 +128,9 @@ export default function LinkMembersPage() {
   );
 }
 
-const Container = styled(SafeAreaView)`
+const Container = styled(SafeAreaView).attrs({
+  edges: ['bottom'],
+})`
   flex: 1;
   padding: 0 ${FEED_PADDING * width}px;
   background-color: ${colors.gray[50]};

--- a/app/(post)/feed/write.tsx
+++ b/app/(post)/feed/write.tsx
@@ -24,6 +24,7 @@ import DescriptionContent from '@/components/feed/write/DescriptionContent';
 import useIOSKeyboardSpacer from '@/hooks/useIOSKeyboardSpacer';
 import ButtonContent from '@/components/feed/write/ButtonContent';
 import { useDelayedLoading } from '@/hooks/useDelayedLoading';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export default function FeedWritePage() {
   const { mode, feedId } = useLocalSearchParams<{
@@ -34,6 +35,7 @@ export default function FeedWritePage() {
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
+  const insets = useSafeAreaInsets();
 
   const { showToast } = useToastStore();
   const { userInfo } = useUserStore();
@@ -239,7 +241,8 @@ export default function FeedWritePage() {
             isBackWhite
             style={{
               position: 'absolute',
-              top: 35,
+              top: insets.top + 16 * height,
+              marginTop: 0,
               width: '100%',
               zIndex: 9999,
               paddingHorizontal: 16 * width,

--- a/app/(post)/leenk/participants-list/index.tsx
+++ b/app/(post)/leenk/participants-list/index.tsx
@@ -153,7 +153,9 @@ export default function ParticipantsList() {
   );
 }
 
-const Container = styled(SafeAreaView)`
+const Container = styled(SafeAreaView).attrs({
+  edges: ['bottom'],
+})`
   flex: 1;
   padding-horizontal: ${CONTAINER_PADDING};
   background-color: ${colors.white};

--- a/ios/Leenk.xcodeproj/project.pbxproj
+++ b/ios/Leenk.xcodeproj/project.pbxproj
@@ -174,6 +174,8 @@
 				TargetAttributes = {
 					13B07F861A680F5B00A75B9A = {
 						LastSwiftMigration = 1250;
+						DevelopmentTeam = "2VCK7Z2C2W";
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -425,9 +427,9 @@
 				CODE_SIGN_ENTITLEMENTS = Leenk/Leenk.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = "2VCK7Z2C2W";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 5DPG335P5J;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -468,9 +470,9 @@
 				CODE_SIGN_ENTITLEMENTS = Leenk/Leenk.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = "2VCK7Z2C2W";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 5DPG335P5J;
 				INFOPLIST_FILE = Leenk/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;


### PR DESCRIPTION
- closed #78

## 📝 Work Description

- 특정 페이지에서만 헤더 밀림 현상 해결 (피드 글쓰기, 피드 함께하는 사람 추가 페이지, 링크 함께한 사람 페이지) 

## 📸 Screenshot
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img width="300" src="이미지 주소" /> -->

<img width="499" height="934" alt="image" src="https://github.com/user-attachments/assets/300fb867-e7f4-4209-89b4-3f7da9ffa313" />

<img width="499" height="934" alt="image" src="https://github.com/user-attachments/assets/47c3992d-3add-4c6e-8811-e7159b2190a6" />

<img width="499" height="934" alt="image" src="https://github.com/user-attachments/assets/b0bf3cfa-ea81-4fcc-b2b3-73ce08855fee" />


## 🚨Issue

## 📣 To Reviewers
- 저번에 #72 여기서 헤더 울컥이는 현상 해결하면서 생긴 문제였던 것 같습니다! 
- 특정 페이지에서만 해당 문제가 발생한 이유는 모든 페이지가 헤더 위치를 같은 방식으로 계산하지 않기 때문,,입니당 

- `components/common/Header/Header.tsx`에서 공통으로 marginTop: insets.top + 16 * height를 넣는 방식
- 어떤 화면은 SafeAreaView가 top inset을 또 먹는 방식
- 어떤 화면은 Header를 position: 'absolute'로 두고 top을 직접 지정하는 방식
- 어떤 화면은 Header 기본 marginTop을 marginTop: 0으로 꺼버리고, 화면에서 top: insets.top + 16 * height를 직접 넣는 방식
이 네 가지가 섞이면, 어떤 페이지는 정상이고 어떤 페이지는 아래로 밀립니다.

이번에 문제가 난 페이지들을 보면 공통점이 있습니다.

`app/(post)/feed/link-members/index.tsx` : 
SafeAreaView(top) + Header(insets.top)가 같이 있어서 top inset이 2번 적용됐습니다.
`app/(post)/feed/write.tsx` : 
Header 기본 marginTop(insets.top)이 있는데, 화면에서 top: 35를 또 줘서 위치 기준이 겹쳤습니다.

라고 하네요 

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 노치가 있는 기기에서 헤더 배치 및 UI 레이아웃 개선
  * 안전 영역 처리 개선으로 화면 표시 최적화

* **기타**
  * 앱 빌드 및 배포 설정 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->