### PR TITLE
[HOTFIX]: cold start 알림 딥링크 유실 및 라우팅 로직 중복 해결

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -24,6 +24,11 @@ import { LogBox } from 'react-native';
 import { getAuthStatus, clearAllTokens } from '@/utils/tokenStorage';
 import * as Clarity from '@microsoft/react-native-clarity';
 import { saveAuthStatus } from '@/utils/tokenStorage';
+import {
+  handleNotificationOpen,
+  markAuthResolved,
+  markNavigatorMounted,
+} from '@/utils/notificationRouter';
 
 export {
   // Catch any errors thrown by the Layout component.
@@ -33,16 +38,6 @@ export {
 export const unstable_settings = {
   // Ensure that reloading on `/modal` keeps a back button present.
   initialRouteName: 'index',
-};
-
-type NotiData = {
-  type?: 'leenk' | 'feed';
-  id?: string | number;
-};
-
-const ROUTES = {
-  leenk: '/leenk/[id]' as const,
-  feed: '/feed/[id]' as const,
 };
 
 LogBox.ignoreLogs([
@@ -105,6 +100,8 @@ export default function RootLayout() {
         router.replace('/');
       } finally {
         setAppReady(true);
+        // 자동 로그인의 replace가 끝난 뒤에 대기 중인 딥링크를 흘려보낸다.
+        markAuthResolved();
         await SplashScreen.hideAsync();
       }
     };
@@ -158,52 +155,24 @@ function RootLayoutNav() {
 
   // =========================
   // 🔔 푸시 알림 → 딥링크 이동 처리
+  // 목적지 해석과 중복 처리는 notificationRouter가 담당한다.
   // =========================
 
-  // 동일 알림으로 중복 네비게이션을 방지하기 위한 Set
-  const handledNotiIdsRef = useRef<Set<string>>(new Set());
-
-  // 알림 data를 해석해서 라우팅하는 헬퍼
-  const navigateFromData = (raw?: Record<string, unknown>) => {
-    const data = (raw ?? {}) as NotiData;
-
-    const type = (data.type ?? '').toString().toLowerCase();
-    const id = data.id != null ? String(data.id).trim() : '';
-    if (!id) return;
-
-    if (type === 'leenk') {
-      // 타입드 라우트: pathname + params 형태
-      router.push({
-        pathname: ROUTES.leenk,
-        params: { id },
-      });
-      return;
-    }
-
-    if (type === 'feed') {
-      router.push({
-        pathname: ROUTES.feed,
-        params: { id },
-      });
-      return;
-    }
-  };
+  useEffect(() => {
+    // Stack이 마운트된 뒤에야 이동이 유실되지 않는다.
+    markNavigatorMounted();
+  }, []);
 
   useEffect(() => {
     // 앱이 실행 중(포어그라운드/백그라운드)일 때 알림을 "탭"한 경우 수신
     const sub = Notifications.addNotificationResponseReceivedListener(
       (resp) => {
-        const id = resp.notification.request.identifier;
-
-        // 이미 처리한 알림이면 무시 (중복 네비 방지)
-        if (handledNotiIdsRef.current.has(id)) return;
-        handledNotiIdsRef.current.add(id);
-
-        // 알림 data로부터 목적지 이동
-        const data = resp.notification.request.content.data as
-          | Record<string, unknown>
-          | undefined;
-        navigateFromData(data);
+        handleNotificationOpen(
+          resp.notification.request.identifier,
+          resp.notification.request.content.data as
+            | Record<string, unknown>
+            | undefined,
+        );
       },
     );
 
@@ -216,14 +185,12 @@ function RootLayoutNav() {
       const last = await Notifications.getLastNotificationResponseAsync();
       if (!last) return;
 
-      const id = last.notification.request.identifier;
-      if (handledNotiIdsRef.current.has(id)) return;
-      handledNotiIdsRef.current.add(id);
-
-      const data = last.notification.request.content.data as
-        | Record<string, unknown>
-        | undefined;
-      navigateFromData(data);
+      handleNotificationOpen(
+        last.notification.request.identifier,
+        last.notification.request.content.data as
+          | Record<string, unknown>
+          | undefined,
+      );
     })();
   }, []);
 

--- a/hooks/useNotification.ts
+++ b/hooks/useNotification.ts
@@ -3,18 +3,13 @@ import messaging, {
   FirebaseMessagingTypes,
 } from '@react-native-firebase/messaging';
 import { Platform } from 'react-native';
-import { router, type Href } from 'expo-router';
 import { requestNotificationPermission } from './usePushNotification';
 import { useInAppNotification } from '@/components/InAppNotificationProvider';
+import { handleNotificationOpen } from '@/utils/notificationRouter';
 
 messaging().setBackgroundMessageHandler(async (remoteMessage) => {
   console.log('[FCM][bg]', summarize(remoteMessage));
 });
-
-const ROUTES = {
-  leenk: '/leenk/[id]' as const,
-  feed: '/feed/[id]' as const,
-};
 
 // 전체 데이터 확인용 로그
 function summarize(msg: FirebaseMessagingTypes.RemoteMessage) {
@@ -27,57 +22,6 @@ function summarize(msg: FirebaseMessagingTypes.RemoteMessage) {
     data: msg.data ?? null,
     sentTime: msg.sentTime ?? null,
   };
-}
-
-// 받은 메시지 → 해당 화면으로 이동 (탭/냉시작에서만 호출)
-function navigateFromMessage(msg: FirebaseMessagingTypes.RemoteMessage) {
-  const d = msg.data ?? {};
-
-  // 지금 들어오는 키에 맞춰 읽기: path + pathId
-  const pathRaw = (d.path ?? d.type ?? '').toString().toLowerCase();
-  const id = (d.pathId ?? d.id ?? '').toString().trim();
-
-  // 단/복수 표기 모두 허용해서 매핑
-  const isLeenk =
-    pathRaw === 'leenks' || pathRaw === 'leenk' || pathRaw === 'link';
-  const isFeed = pathRaw === 'feeds' || pathRaw === 'feed';
-  const isBirthday = pathRaw === 'birthday';
-
-  if (isBirthday) {
-    const type = d['notificationType'];
-
-    if (type === 'BIRTHDAY_LETTER') {
-      // 받은 생일 편지 목록
-      router.push('/extra/birthday/letters');
-      return;
-    }
-
-    if (type === 'BIRTHDAY_CELEBRATE' || type === 'BIRTHDAY_ANNOUNCEMENT') {
-      // 생일 메인
-      router.push('/extra');
-      return;
-    }
-
-    // fallback
-    router.push('/extra');
-    return;
-  }
-
-  if (!id) {
-    // console.log('[FCM] id가 없어서 상세로 이동할 수 없어요:', d);
-    return;
-  }
-
-  if (isLeenk) {
-    router.push({ pathname: ROUTES.leenk, params: { id } });
-    return;
-  }
-  if (isFeed) {
-    router.push({ pathname: ROUTES.feed, params: { id } });
-    return;
-  }
-
-  // console.log('[FCM] 알 수 없는 path:', pathRaw, d);
 }
 
 export default function NotificationInitializer() {
@@ -106,7 +50,7 @@ export default function NotificationInitializer() {
     // 2) 알림 "탭"해서 앱 열림(백→포그라운드)
     const unsubOpened = messaging().onNotificationOpenedApp((m) => {
       // console.log('[FCM][tap]', summarize(m));
-      navigateFromMessage(m);
+      handleNotificationOpen(m.messageId ?? undefined, m.data);
     });
 
     // 3) Cold start(앱 종료) 상태에서 알림으로 시작
@@ -114,7 +58,7 @@ export default function NotificationInitializer() {
       const initial = await messaging().getInitialNotification();
       if (initial) {
         // console.log('[FCM][cold]', summarize(initial));
-        navigateFromMessage(initial);
+        handleNotificationOpen(initial.messageId ?? undefined, initial.data);
       }
     })();
 

--- a/utils/notificationRouter.test.ts
+++ b/utils/notificationRouter.test.ts
@@ -1,0 +1,142 @@
+jest.mock('expo-router', () => ({
+  router: { push: jest.fn() },
+}));
+
+import { router } from 'expo-router';
+import {
+  resolveDestination,
+  handleNotificationOpen,
+  markAuthResolved,
+  markNavigatorMounted,
+  resetNotificationRouterForTest,
+} from './notificationRouter';
+
+const routerPush = router.push as jest.Mock;
+
+// 준비 완료 상태로 만들어 두는 헬퍼
+const makeReady = () => {
+  markAuthResolved();
+  markNavigatorMounted();
+};
+
+beforeEach(() => {
+  resetNotificationRouterForTest();
+  routerPush.mockClear();
+});
+
+describe('resolveDestination', () => {
+  it('FCM의 path/pathId 형태를 읽는다', () => {
+    expect(resolveDestination({ path: 'leenks', pathId: '12' })).toEqual({
+      pathname: '/leenk/[id]',
+      params: { id: '12' },
+    });
+  });
+
+  it('expo-notifications의 type/id 형태를 읽는다', () => {
+    expect(resolveDestination({ type: 'feed', id: 34 })).toEqual({
+      pathname: '/feed/[id]',
+      params: { id: '34' },
+    });
+  });
+
+  it('단수와 복수 표기를 모두 허용한다', () => {
+    expect(resolveDestination({ path: 'leenk', pathId: '1' })).toEqual(
+      resolveDestination({ path: 'leenks', pathId: '1' }),
+    );
+  });
+
+  it('생일 편지 알림은 편지함으로 보낸다', () => {
+    expect(
+      resolveDestination({
+        path: 'birthday',
+        notificationType: 'BIRTHDAY_LETTER',
+      }),
+    ).toEqual({ pathname: '/extra/birthday/letters' });
+  });
+
+  it('id가 없으면 목적지를 만들지 않는다', () => {
+    expect(resolveDestination({ path: 'leenk' })).toBeNull();
+  });
+
+  it('모르는 path면 목적지를 만들지 않는다', () => {
+    expect(resolveDestination({ path: 'unknown', pathId: '1' })).toBeNull();
+  });
+});
+
+describe('cold start 지연 라우팅', () => {
+  it('준비 전에 들어온 알림은 즉시 이동하지 않는다', () => {
+    handleNotificationOpen('noti-1', { path: 'leenk', pathId: '7' });
+
+    expect(routerPush).not.toHaveBeenCalled();
+  });
+
+  it('자동 로그인만 끝난 상태에서는 아직 이동하지 않는다', () => {
+    handleNotificationOpen('noti-1', { path: 'leenk', pathId: '7' });
+    markAuthResolved();
+
+    expect(routerPush).not.toHaveBeenCalled();
+  });
+
+  it('자동 로그인과 네비게이터가 모두 준비되면 보관해둔 목적지로 이동한다', () => {
+    handleNotificationOpen('noti-1', { path: 'leenk', pathId: '7' });
+    makeReady();
+
+    expect(routerPush).toHaveBeenCalledTimes(1);
+    expect(routerPush).toHaveBeenCalledWith({
+      pathname: '/leenk/[id]',
+      params: { id: '7' },
+    });
+  });
+
+  it('준비가 끝난 뒤에 들어온 알림은 바로 이동한다', () => {
+    makeReady();
+    handleNotificationOpen('noti-1', { path: 'feed', pathId: '9' });
+
+    expect(routerPush).toHaveBeenCalledWith({
+      pathname: '/feed/[id]',
+      params: { id: '9' },
+    });
+  });
+});
+
+describe('중복 이동 방지', () => {
+  it('같은 알림 ID는 한 번만 처리한다', () => {
+    makeReady();
+    handleNotificationOpen('noti-1', { path: 'leenk', pathId: '7' });
+    handleNotificationOpen('noti-1', { path: 'leenk', pathId: '7' });
+
+    expect(routerPush).toHaveBeenCalledTimes(1);
+  });
+
+  it('알림 ID 체계가 달라도 같은 목적지면 한 번만 이동한다', () => {
+    makeReady();
+    // FCM messageId와 expo identifier가 서로 다른 값으로 같은 탭을 전달하는 상황
+    handleNotificationOpen('fcm-message-id', { path: 'leenk', pathId: '7' });
+    handleNotificationOpen('expo-identifier', { type: 'leenk', id: '7' });
+
+    expect(routerPush).toHaveBeenCalledTimes(1);
+  });
+
+  it('cold start에서 두 리스너가 같은 알림을 전달해도 한 번만 이동한다', () => {
+    handleNotificationOpen('fcm-message-id', { path: 'leenk', pathId: '7' });
+    handleNotificationOpen('expo-identifier', { type: 'leenk', id: '7' });
+    makeReady();
+
+    expect(routerPush).toHaveBeenCalledTimes(1);
+  });
+
+  it('목적지가 다르면 각각 이동한다', () => {
+    makeReady();
+    handleNotificationOpen('noti-1', { path: 'leenk', pathId: '7' });
+    handleNotificationOpen('noti-2', { path: 'leenk', pathId: '8' });
+
+    expect(routerPush).toHaveBeenCalledTimes(2);
+  });
+
+  it('해석할 수 없는 알림은 이동하지 않는다', () => {
+    makeReady();
+    handleNotificationOpen('noti-1', { path: 'leenk' });
+
+    expect(routerPush).not.toHaveBeenCalled();
+  });
+});

--- a/utils/notificationRouter.ts
+++ b/utils/notificationRouter.ts
@@ -1,0 +1,145 @@
+import { router } from 'expo-router';
+
+const LEENK_ROUTE = '/leenk/[id]' as const;
+const FEED_ROUTE = '/feed/[id]' as const;
+const BIRTHDAY_LETTERS_ROUTE = '/extra/birthday/letters' as const;
+const BIRTHDAY_ROUTE = '/extra' as const;
+
+export type NotificationData = Record<string, unknown> | undefined;
+
+export type Destination =
+  | { pathname: typeof LEENK_ROUTE; params: { id: string } }
+  | { pathname: typeof FEED_ROUTE; params: { id: string } }
+  | { pathname: typeof BIRTHDAY_LETTERS_ROUTE }
+  | { pathname: typeof BIRTHDAY_ROUTE };
+
+const toText = (value: unknown) => (value == null ? '' : String(value).trim());
+
+/**
+ * 알림 페이로드에서 목적지를 해석한다.
+ * FCM은 path/pathId, expo-notifications는 type/id로 내려와서 양쪽 키를 모두 받는다.
+ * 해석할 수 없으면 null을 반환해 이동하지 않는다.
+ */
+export const resolveDestination = (data: NotificationData): Destination | null => {
+  const payload = data ?? {};
+  const path = toText(payload.path ?? payload.type).toLowerCase();
+  const id = toText(payload.pathId ?? payload.id);
+
+  if (path === 'birthday') {
+    const notificationType = toText(payload.notificationType);
+    if (notificationType === 'BIRTHDAY_LETTER') {
+      return { pathname: BIRTHDAY_LETTERS_ROUTE };
+    }
+    return { pathname: BIRTHDAY_ROUTE };
+  }
+
+  if (!id) return null;
+
+  if (path === 'leenk' || path === 'leenks' || path === 'link') {
+    return { pathname: LEENK_ROUTE, params: { id } };
+  }
+
+  if (path === 'feed' || path === 'feeds') {
+    return { pathname: FEED_ROUTE, params: { id } };
+  }
+
+  return null;
+};
+
+const destinationKey = (destination: Destination) =>
+  'params' in destination
+    ? `${destination.pathname}:${destination.params.id}`
+    : destination.pathname;
+
+// 자동 로그인 완료와 네비게이터 마운트가 모두 끝나야 이동을 흘려보낸다.
+let authResolved = false;
+let navigatorMounted = false;
+
+let pendingDestination: Destination | null = null;
+
+// 같은 알림이 두 리스너에 동시에 잡히는 경우를 거르기 위한 기록
+const handledNotificationIds = new Set<string>();
+const DUPLICATE_WINDOW_MS = 1000;
+let lastNavigation: { key: string; at: number } | null = null;
+
+const isReady = () => authResolved && navigatorMounted;
+
+const navigate = (destination: Destination) => {
+  const key = destinationKey(destination);
+  const now = Date.now();
+
+  // FCM과 expo-notifications는 알림 ID 체계가 달라 ID만으로는 중복을 못 거른다.
+  // 같은 목적지로의 연속 이동은 짧은 시간 안에서 한 번만 허용한다.
+  if (
+    lastNavigation &&
+    lastNavigation.key === key &&
+    now - lastNavigation.at < DUPLICATE_WINDOW_MS
+  ) {
+    return;
+  }
+  lastNavigation = { key, at: now };
+
+  switch (destination.pathname) {
+    case LEENK_ROUTE:
+      router.push({ pathname: LEENK_ROUTE, params: destination.params });
+      return;
+    case FEED_ROUTE:
+      router.push({ pathname: FEED_ROUTE, params: destination.params });
+      return;
+    default:
+      router.push(destination.pathname);
+  }
+};
+
+const flushPending = () => {
+  if (!isReady()) return;
+
+  const destination = pendingDestination;
+  pendingDestination = null;
+  if (destination) navigate(destination);
+};
+
+/** 자동 로그인 분기가 끝났을 때 호출한다. */
+export const markAuthResolved = () => {
+  authResolved = true;
+  flushPending();
+};
+
+/** 루트 네비게이터가 마운트됐을 때 호출한다. */
+export const markNavigatorMounted = () => {
+  navigatorMounted = true;
+  flushPending();
+};
+
+/**
+ * 알림 탭을 처리한다.
+ * 앱이 아직 준비되지 않았으면 목적지를 보관했다가 준비 완료 직후 이동한다.
+ */
+export const handleNotificationOpen = (
+  notificationId: string | undefined,
+  data: NotificationData,
+) => {
+  if (notificationId) {
+    if (handledNotificationIds.has(notificationId)) return;
+    handledNotificationIds.add(notificationId);
+  }
+
+  const destination = resolveDestination(data);
+  if (!destination) return;
+
+  if (!isReady()) {
+    pendingDestination = destination;
+    return;
+  }
+
+  navigate(destination);
+};
+
+/** 테스트 전용: 모듈 상태 초기화 */
+export const resetNotificationRouterForTest = () => {
+  authResolved = false;
+  navigatorMounted = false;
+  pendingDestination = null;
+  handledNotificationIds.clear();
+  lastNavigation = null;
+};


### PR DESCRIPTION
## 📝 Work Description

- `utils/notificationRouter.ts` 추가 — 알림 딥링크 라우팅을 한 곳으로 모았습니다.
  - 자동 로그인 분기와 네비게이터 마운트가 **모두** 끝난 뒤에 이동하도록 지연 처리
  - 준비 전에 들어온 알림은 목적지를 보관했다가 준비 직후 이동
  - FCM(`path`/`pathId`)과 expo-notifications(`type`/`id`) 페이로드를 함께 해석
  - 두 라이브러리의 알림 ID 체계가 달라 거를 수 없던 중복 이동을 목적지 기준으로 차단
- `app/_layout.tsx`와 `hooks/useNotification.ts`에 중복돼 있던 라우팅 로직 통합
- 단위 테스트 15개 추가

## 🚨 Issue

**앱이 종료된 상태에서 알림을 탭해 진입하면 목적지 화면이 목록으로 덮일 수 있었습니다.**

`_layout.tsx`의 `autoLogin`은 `getUsersInfo()` 응답을 기다린 뒤 `router.replace('/leenk')`를 호출하는데, 딥링크 이동(`getInitialNotification`, `getLastNotificationResponseAsync`)은 각자 별도 `useEffect`에서 `router.push`를 합니다. 두 네비게이션에 순서를 보장하는 장치가 없어서, 서버 응답이 늦으면 상세로 갔다가 `replace`가 덮어씁니다.

`appReady` state가 이미 있었지만 선언만 되어 있고 아무것도 게이팅하지 않는 상태였습니다.

부수적으로 라우팅 로직이 두 곳에 중복돼 있었습니다. `useNotification.ts`는 `path`/`pathId`에 생일 분기까지 있고, `_layout.tsx`는 `type`/`id`만 읽어서 **expo-notifications 경로로 들어온 생일 알림은 이동하지 않았습니다.** 중복 방지 Set도 `_layout.tsx`에만 있었습니다.

## 📣 To Reviewers

- 준비 완료 신호를 `authResolved`와 `navigatorMounted` 두 개로 나눴습니다. 폰트 로딩 때문에 `RootLayoutNav`가 늦게 마운트될 수 있어서, 자동 로그인만 기준으로 삼으면 `Stack`이 없는 상태로 `push`가 나갈 수 있다고 판단했습니다.
- 중복 방지를 알림 ID + 목적지(1초 윈도우) 두 단계로 뒀습니다. FCM `messageId`와 expo `identifier`가 같은 탭에 서로 다른 값을 주기 때문에 ID만으로는 cold start에서 두 리스너가 각각 이동하는 걸 못 막습니다.
- `_layout.tsx`에서도 생일 알림 라우팅이 동작하게 됐습니다. 의도한 동작이 맞는지 확인 부탁드립니다.
- 실기기 확인은 아직 못 했습니다. 앱 종료 상태에서 알림 탭 → 상세 진입 유지되는지 봐주시면 좋겠습니다.

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요? — `tsc` 에러가 develop 12개 → 이 브랜치 10개로 감소
- [x] merge할 브랜치의 위치를 확인했나요? — `develop`
- [ ] Label을 지정했나요?

<details>
<summary>테스트 결과</summary>

```
PASS utils/notificationRouter.test.ts
  resolveDestination (6)
  cold start 지연 라우팅 (4)
  중복 이동 방지 (5)

Test Suites: 2 passed, 2 total
Tests:       20 passed, 20 total
```
</details>

> `utils/notificationRouter.ts:90`의 `/extra/birthday/letters` 타입 에러는 `.expo/types` 코드젠이 오래돼서 나는 가짜 에러입니다. 라우트 파일은 실제로 존재하고, `app/(page)/extra.tsx`·`app/account/notification-list.tsx`에도 같은 에러가 이미 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 푸시 알림을 탭하면 로그인 및 화면 준비 상태와 관계없이 올바른 관련 화면으로 이동합니다.
  - 앱이 완전히 종료된 상태에서 알림을 열어도 해당 화면으로 정상 이동합니다.
  - 동일한 알림으로 화면이 중복 이동하는 현상을 방지했습니다.
  - 지원되지 않거나 정보가 부족한 알림은 잘못된 화면으로 이동하지 않습니다.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->